### PR TITLE
✨ relocate checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       # uses lean standard action with all default input values
       - uses: leanprover/lean-action
 ```

--- a/action.yml
+++ b/action.yml
@@ -56,8 +56,6 @@ runs:
       run: ${{ github.action_path }}/scripts/install_elan.sh
       shell: bash
 
-    - uses: actions/checkout@v4
-
     - uses: actions/cache@v4
       with:
         path: .lake


### PR DESCRIPTION
Remove `- uses: actions/checkout@v4` from the action and specify in the readme to use the comand in workflows.

Motivation:

1. This matches common practice in actions, eg: 

- [Github Action with TeXLive](https://github.com/marketplace/actions/github-action-with-texlive)
- [GH Release](https://github.com/marketplace/actions/gh-release)
- [Setup Node.js environment](https://github.com/marketplace/actions/setup-node-js-environment)
- [run-ansible-lint](https://github.com/marketplace/actions/run-ansible-lint)

2. This enables the use case when the workflow where `lean-action` is used first checks out a  copy of the repo, then does something else before using `lean-action`.

