### PR TITLE
:memo:   Update README.md to recommend dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,18 @@ jobs:
     test: false
     mathlib-cache: false
 ```
+
+## Keep the action updated with `dependabot`
+
+In order to receive notification when this action is updated (and any others used in your repo), add the file `.github/dependabot.yml` with the contents:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions" 
+    directory: "/"
+    schedule:
+      interval: "daily"
+```
+
+See the [dependabot documentation](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) for all configuration options.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ jobs:
 ```
 
 ## Keep the action updated with `dependabot`
+Because Lean is under heavy development, changes to Lean or Lake could break outdated versions of `lean-action`. You can configure [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to automatically create a PR to update `lean-action` when a new stable version is released. 
 
-In order to receive notification when this action is updated (and any others used in your repo), add the file `.github/dependabot.yml` with the contents:
+Here is an example `.github/dependabot.yml` which configures `dependabot` to check daily for updates to all GitHub actions in your repository:
 
 ```yaml
 version: 2


### PR DESCRIPTION
In anticipation of `lean-action` often being updated, most likely because the underlying lean / lake / etc is updated, recommend all users of the action to take advantage of dependabot. In such a way the repos using the action receive notification when updates happen.