### PR TITLE
feat: add `build-args` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - logs are grouped by step for better readability
+- `build-args` input to specify arguments to pass to `lake build`
 
 ### Changed
 - `lean-action` no longer contains an `actions/checkout` step

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ jobs:
     # Allowed values: "true" or "false".
     # Default: true
     test: true
+    
+    # Build arguments to pass to `lake build {args}`.
+    # For example, `build-args: "--quiet"` will run `lake build --quiet`.
+    build-args: ""
 
     # Run "lake exe cache get" before build.
     # Project must be downstream of Mathlib.
@@ -79,6 +83,14 @@ jobs:
   with:
     test: false
     mathlib-cache: false
+```
+
+### Run lake build with `--wfail`
+
+```yaml
+- uses: leanprover/lean-action@v1-alpha
+  with:
+    build-args: "--wfail"
 ```
 
 ## Keep the action updated with `dependabot`

--- a/action.yml
+++ b/action.yml
@@ -87,10 +87,10 @@ runs:
 
     - name: build ${{ github.repository }}
       env: 
-          BUILD-ARGS: ${{ inputs.build-args }}
+          BUILD_ARGS: ${{ inputs.build-args }}
       run: |
         echo "::group::Lake Build"
-        lake build "$BUILD-ARGS"
+        lake build "$BUILD_ARGS"
         echo "::endgroup::"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -86,9 +86,11 @@ runs:
       shell: bash
 
     - name: build ${{ github.repository }}
+      env: 
+          BUILD-ARGS: ${{ inputs.build-args }}
       run: |
         echo "::group::Lake Build"
-        lake build ${{ inputs.build-args }}
+        lake build "$BUILD-ARGS"
         echo "::endgroup::"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
       If test input is not provided, tests will run by default.
     required: false
     default: "true"
+  build-args:
+    description: |
+      Build arguments to pass to `lake build {args}`.
+      For example, `build-args: "--quiet"` will run `lake build --quiet`.
+    required: false
+    default: ""
   mathlib-cache:
     description: |
       Run "lake exe cache get" before build.
@@ -82,7 +88,7 @@ runs:
     - name: build ${{ github.repository }}
       run: |
         echo "::group::Lake Build"
-        lake build
+        lake build ${{ inputs.build-args }}
         echo "::endgroup::"
       shell: bash
 


### PR DESCRIPTION
Pass a new `build-args` input to `lake build` in the build step.

 
closes #15 