### PR TITLE
feat: convenience workflow for update major release tag

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,39 @@
+name: Update major version tag
+run-name: Set ${{ github.event.inputs.major_version }} to point to ${{ github.event.inputs.target }}
+
+# Each time there is a minor release, this workflow can be manually run in order to update the major release tag to point to the latest release.
+# Can also be used for rollback if the latest release is found to have problems.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: The tag or reference to use
+        required: true
+      major_version:
+        type: choice
+        description: The major version to update
+        options:
+          - v1-alpha
+          - v1
+        # add items to this list when new major releases are released
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # required to commit to the repo
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Tag new target
+        run: git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+      - name: Push new tag
+        run: git push origin ${{ github.event.inputs.major_version }} --force
+
+    # bot user details: https://api.github.com/users/github-actions%5Bbot%5D

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ For more information about releasing GitHub actions see the [Using tags for rele
     - Test `lean-action` by pointing an existing test repository to the new version with `uses: leanprover/lean-action@v{RELEASE_VERSION}`.
     - Make any minor commits related to the release on the release branch.
 - Once the release has been validated, create a new release with release notes copied from the `## Unreleased` section of `CHANGELOG.md` and a git tag `v{RELEASE_VERSION}` (e.g `v2.7.1`).
-- In the case of a minor or patch version, move the major version tag to the latest version
+- In the case of a minor or patch version, move the major version tag to the latest version. This can be done by manually running the "Update major version tag" workflow.
 - Update `CHANGELOG.md` with a new section with the release name and date directly below the `## Unreleased` header, e.g., `## v2.7.1 - 2024-12-21` .
     - If you made updates to the release notes in the GitHub release, add them to `CHANGELOG.md`.
 - If there are additional commits on the release branch, merge the release branch back into `main`.


### PR DESCRIPTION
Adds a workflow which can be called manually (workflow_dispatch) and gives a convenient way to update the major tag to point to the latest release (or roll back to a previous release if required).  