### PR TITLE
feat: add `use-github-cache` input

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -54,3 +54,4 @@ jobs:
         uses: ./
         with:
           test: ${{ matrix.lake-test }}
+          use-github-cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- new `github-cache` input to specify if `lean-action` should use `actions/cache` to cache the `.lake` folder
+- new `use-github-cache` input to specify if `lean-action` should use `actions/cache` to cache the `.lake` folder
 
 ## v1-beta - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- new `github-cache` input to specify if `lean-action` should use `actions/cache` to cache the `.lake` folder
+
 ## v1-beta - 2024-05-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ jobs:
     # Allowed values: "true" or "false".
     # Default: false
     lean4checker: false 
+
+    
+    # Enable GitHub caching.
+    # Allowed values: "true" or "false".
+    # If use-github-cache input is not provided, the action will use GitHub caching by default.
+    use-github-cache: true
 ```
 
 ## Examples

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,13 @@ inputs:
       If lean4checker input is not provided, the action will not check the environment with lean4checker.
     required: false
     default: "false"
+  use-github-cache:
+    description: |
+      Enable GitHub caching.
+      Allowed values: "true" or "false".
+      If use-github-cache input is not provided, `lean-action` will use GitHub caching by default.
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -63,6 +70,7 @@ runs:
       shell: bash
 
     - uses: actions/cache@v4
+      if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: .lake
         key: ${{ runner.os }}-lake-${{ github.sha }}
@@ -95,6 +103,7 @@ runs:
       shell: bash
 
     - uses: actions/cache/save@v4
+      if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: .lake
         key: ${{ runner.os }}-lake-${{ github.sha }}


### PR DESCRIPTION
`use-github-cache` input specifies if `lean-action` should use `actions/cache`.

`lean-action`'s ci workflows are currently the primary use case for disabling `action/cache`.