### PR TITLE
Revert "refactor: move functional tests to a dedicated directory"

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "scripts/**"
       - "action.yml"
-      - ".github/workflows/functional_tests/lake_init.yml"
+      - ".github/workflows/functional_tests.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Moving functional tests to a subdirectory doesn't work correctly. We can use actions instead. 

Reverts leanprover/lean-action#49