### PR TITLE
fix: remove `elan-init` file

### DIFF
--- a/scripts/install_elan.sh
+++ b/scripts/install_elan.sh
@@ -6,6 +6,8 @@ echo "::group::Elan Installation Output"
 set -o pipefail
 curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
 ./elan-init -y --default-toolchain none
+rm -f elan-init
+
 echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 "$HOME"/.elan/bin/lean --version          
 "$HOME"/.elan/bin/lake --version


### PR DESCRIPTION
Depending on the usage, elan-init files may remain. For example, when the “commit all changes” action is executed after lean-action.