### PR TITLE
feat: don't raise an error if test_runner is not provided

### DIFF
--- a/.github/functional_tests/lake_test/action.yml
+++ b/.github/functional_tests/lake_test/action.yml
@@ -1,6 +1,6 @@
 name: 'Lake Test Functional Tests'
 description: 'Run `lean-action` with `lake test` and a dummy test_runner'
-runs: 
+runs:
   using: 'composite'
   steps:
     # TODO: once `lean-action` supports just setup, use it here
@@ -16,7 +16,7 @@ runs:
       run: |
         lake init dummytest
       shell: bash
-    
+
     - name: create dummy test
       run: |
         {
@@ -24,12 +24,12 @@ runs:
           echo "script dummy_test do"
           echo "  println! \"Running fake tests...\""
           echo "  println! \"Fake tests passed!\""
-          echo "  return 0" 
+          echo "  return 0"
         } >> lakefile.lean
       shell: bash
 
-    - name: "run `lean-action` with `lake test`" 
+    - name: "run `lean-action` with `lake test`"
       uses: ./
       with:
-        test: true
+        test: "auto"
         use-github-cache: false

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "Lean Action - CI for Lean Projects"
 description: |
-  Standard CI for Lean projects. 
+  Standard CI for Lean projects.
   Steps:
     - install elan
     - get Mathlib cache (optional, must be downstream of Mathlib)
@@ -12,10 +12,10 @@ inputs:
   test:
     description: |
       Run lake test.
-      Allowed values: "true" or "false".
-      If test input is not provided, tests will run by default.
+      Allowed values: "auto" | "false".
+      If test runner is provided, tests will run by default.
     required: false
-    default: "true"
+    default: "auto"
   build-args:
     description: |
       Build arguments to pass to `lake build {args}`.
@@ -100,7 +100,7 @@ runs:
       shell: bash
 
     - name: build ${{ github.repository }}
-      env: 
+      env:
           BUILD_ARGS: ${{ inputs.build-args }}
       run: |
         : Lake Build
@@ -117,7 +117,7 @@ runs:
         key: ${{ runner.os }}-lake-${{ github.sha }}
 
     - name: test ${{ github.repository }}
-      if: ${{ inputs.test == 'true' }}
+      if: ${{ inputs.test == 'auto' }}
       run: |
         : Lake Test
         ${{ github.action_path }}/scripts/lake_test.sh

--- a/scripts/lake_test.sh
+++ b/scripts/lake_test.sh
@@ -7,12 +7,13 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 # use `lake check-test` to determine if the project has a test runner available
 # TODO: add a more helpful error message once the test frame work matures
 if ! lake check-test; then
-    echo "::error::lake check-test failed: could not find a test runner"
+    echo "lake check-test failed: could not find a test runner"
     cat "$SCRIPT_DIR"/step_summaries/lake_check_error.md >> "$GITHUB_STEP_SUMMARY"
-    exit 1
+else
+    echo "test runner found!"
+    lake test
 fi
 
-lake test
 
 echo "::endgroup::"
 echo

--- a/scripts/step_summaries/lake_check_error.md
+++ b/scripts/step_summaries/lake_check_error.md
@@ -1,2 +1,2 @@
 ### `lake check-test` failed
-`lake check-test` could not find a test runner. Add script or lean_exe tagged `@[test_runner]` in the workspace's root package.
+`lake check-test` could not find a test runner. Consider adding script or lean_exe tagged `@[test_runner]` in the workspace's root package.


### PR DESCRIPTION
It is tedious to pass the option to run `lake test` or not every time. It would be better to explicitly pass `false` only when the user does not want to run lake-test.

When calling lean-action from another GitHub Action, it is more convenient to avoid errors when there is no test runner.

resolve #53 