### PR TITLE
feat: switch elan installation method from  tar -> `elan-init.sh`

### DIFF
--- a/.github/functional_tests/auto_config_false/action.yml
+++ b/.github/functional_tests/auto_config_false/action.yml
@@ -15,8 +15,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/auto_config_true/action.yml
+++ b/.github/functional_tests/auto_config_true/action.yml
@@ -14,8 +14,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_check_test_failure/action.yml
+++ b/.github/functional_tests/lake_check_test_failure/action.yml
@@ -13,8 +13,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_init_failure/action.yml
+++ b/.github/functional_tests/lake_init_failure/action.yml
@@ -11,8 +11,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_init_success/action.yml
+++ b/.github/functional_tests/lake_init_success/action.yml
@@ -14,8 +14,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_lint_failure/action.yml
+++ b/.github/functional_tests/lake_lint_failure/action.yml
@@ -11,8 +11,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_lint_success/action.yml
+++ b/.github/functional_tests/lake_lint_success/action.yml
@@ -11,8 +11,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_test_failure/action.yml
+++ b/.github/functional_tests/lake_test_failure/action.yml
@@ -11,8 +11,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/lake_test_success/action.yml
+++ b/.github/functional_tests/lake_test_success/action.yml
@@ -11,8 +11,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/functional_tests/subdirectory_lake_package/action.yml
+++ b/.github/functional_tests/subdirectory_lake_package/action.yml
@@ -13,8 +13,7 @@ runs:
     - name: install elan
       run: |
         set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain ${{ inputs.toolchain }}
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
         echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
       shell: bash
 

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -109,3 +109,13 @@ jobs:
       - uses: ./.github/functional_tests/subdirectory_lake_package
         with:
           toolchain: ${{ env.toolchain }}
+  
+  macos-runner:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/functional_tests/lake_init_success
+        with:
+          lake-init-arguments: "standalone"
+          toolchain: ${{ env.toolchain }}
+

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -111,7 +111,7 @@ jobs:
           toolchain: ${{ env.toolchain }}
   
   macos-runner:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/functional_tests/lake_init_success

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- switch elan installation method from download platform tar to `elan-init.sh`
+to support addition runners, e.g., macos.
+
 ## v1.0.0 - 2024-07-20
+
 ### Added
 
 - new `auto-config` input

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ lean-action provides steps to build, test, and lint [Lean](https://github.com/le
 
 ## Quick Setup
 
-To setup lean-action to run on pushes and pull request in your repo, create the following `ci.yml` file the `.github/workflows`
+To setup `lean-action` to run on pushes and pull request in your repo, create the following `ci.yml` file the `.github/workflows`
 
 ```yml
 name: CI
@@ -26,6 +26,11 @@ jobs:
       - uses: leanprover/lean-action@v1
 ```
 
+> [!IMPORTANT]
+`lean-action` is tested on `ubuntu-latest` and `macos-latest` GitHub-hosted runners,
+and should support Unix-based runners in general.
+Currently, `lean-action` does not support window runners.
+
 ## Configuring which features `lean-action` runs
 
 Most use cases only require a subset of `lean-action`'s features
@@ -38,6 +43,7 @@ To support these use cases,
 `lean-action` provides inputs to specify the subset of desired features of `lean-action`.
 
 ### Directly specifying a desired feature with specific feature inputs
+
 Each feature of `lean-action` has a corresponding input which users can set to `true` or `false`.
 Specific feature inputs have the highest precedence
 when `lean-action` determines which features to run.
@@ -45,6 +51,7 @@ When a feature input is set `lean-action` will always try to run the correspondi
 If `lean-action` is unable to successfully run the step, `lean-action` will fail.
 
 `lean-action` provides the following feature inputs:
+
 - `build`
 - `test`
 - `lint`
@@ -52,6 +59,7 @@ If `lean-action` is unable to successfully run the step, `lean-action` will fail
 - `lean4checker`
 
 ### Automatic configuration
+
 After feature inputs, `lean-action` uses the `auto-config` input
 to determine if it should use the Lake workspace to decide which steps to run automatically.
 When `auto-config: true`, `lean-action` will use the Lake workspace to detect targets
@@ -60,11 +68,13 @@ When `auto-config: false`, `lean-action` will only run features specified direct
 Users can combine `auto-config` with specific feature inputs to override the automatic configuration of `lean-action`.
 
 `lean-action` can automatically configure the following features:
+
 - `build`
 - `test`
 - `lint`
 
 ### Breaking up `lean-action` across workflows
+
 Sometimes it is useful to break up usage of `lean-action`
 across multiple workflows with different triggers,
 e.g., one workflow for PRs and another workflow scheduled by a cron job.
@@ -82,6 +92,7 @@ For example, run only `lean4checker` in a cron job workflow:
 ```
 
 ### Differences between using `auto-config` and feature inputs
+
 When you specify a feature with a feature input, `lean-action` will fail if it can't complete that step.
 However, if you use `auto-config`,
 `lean-action` will only fail if it detects a target in the Lake workspace and the detected target fails.
@@ -94,6 +105,7 @@ because `lean-action` may not detect the `test_driver` in the Lake workspace.
 To be certain `lean-action` runs a step, specify the desire feature with a feature input.
 
 ## Customization
+
 `lean-action` provides optional configuration inputs to customize the behavior for your specific workflow.
 
 ```yaml
@@ -161,12 +173,14 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 ```
 
 ## Output Parameters
+
 `lean-action` provides the following output parameters for downstream steps:
 
-- `build-status` 
+- `build-status`
   - Values: "SUCCESS" | "FAILURE" | "NOT_RUN"
 - `test-status`
   - Values: "SUCCESS" | "FAILURE" | "NOT_RUN"
+
 ### Example: Use `test-status` output parameter in downstream step
 
 ```yaml
@@ -228,13 +242,14 @@ steps:
       rm import_graph.dot
 ```
 
-
 ## Projects which use `lean-action`
+
 - [leanprover-community/aesop](https://github.com/leanprover-community/aesop/blob/master/.github/workflows/build.yml#L16)
 - [leanprover-community/import-graph](https://github.com/leanprover-community/import-graph/blob/main/.github/workflows/build.yml#L8)
 
 ## Keep the action updated with `dependabot`
-Because Lean is under heavy development, changes to Lean or Lake could break outdated versions of `lean-action`. You can configure [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to automatically create a PR to update `lean-action` when a new stable version is released. 
+
+Because Lean is under heavy development, changes to Lean or Lake could break outdated versions of `lean-action`. You can configure [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to automatically create a PR to update `lean-action` when a new stable version is released.
 
 Here is an example `.github/dependabot.yml` which configures `dependabot` to check daily for updates to all GitHub actions in your repository:
 

--- a/scripts/install_elan.sh
+++ b/scripts/install_elan.sh
@@ -4,7 +4,6 @@
 echo "::group::Elan Installation Output"
 
 set -o pipefail
-# curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
 curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf |
   sh -s -- -y --default-toolchain none
 rm -f elan-init

--- a/scripts/install_elan.sh
+++ b/scripts/install_elan.sh
@@ -4,12 +4,13 @@
 echo "::group::Elan Installation Output"
 
 set -o pipefail
-curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-./elan-init -y --default-toolchain none
+# curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf |
+  sh -s -- -y --default-toolchain none
 rm -f elan-init
 
-echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-"$HOME"/.elan/bin/lean --version          
+echo "$HOME/.elan/bin" >>"$GITHUB_PATH"
+"$HOME"/.elan/bin/lean --version
 "$HOME"/.elan/bin/lake --version
 
 echo "::endgroup::"


### PR DESCRIPTION
Using `elan-init.sh` will make the `install_elan.sh` script easier to maintain and allow lean-action to support additional runners, e.g. macos.

Additionally, update all instances of elan installation in the functional tests to use `elan-init.sh`

Closes #83 