### PR TITLE
fix: remove set-output-parameters step to fix log group expansion

### DIFF
--- a/.github/functional_tests/auto_config_false/action.yml
+++ b/.github/functional_tests/auto_config_false/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: verify `lake build` not run
       env:
         OUTPUT_NAME: "build-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.build-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -51,7 +51,7 @@ runs:
     - name: verify `lake test` not run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -59,7 +59,7 @@ runs:
     - name: verify `lake lint` not run
       env:
         OUTPUT_NAME: "lint-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -83,7 +83,7 @@ runs:
     - name: verify `lake build` not run
       env:
         OUTPUT_NAME: "build-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action-lean4checker.outputs.build-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -91,7 +91,7 @@ runs:
     - name: verify `lake test` not run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action-lean4checker.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -99,7 +99,7 @@ runs:
     - name: verify `lake lint` not run
       env:
         OUTPUT_NAME: "lint-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/.github/functional_tests/lake_check_test_failure/action.yml
+++ b/.github/functional_tests/lake_check_test_failure/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: verify `lake build` not run
       env:
         OUTPUT_NAME: "build-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.build-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash
@@ -50,7 +50,7 @@ runs:
     - name: verify `lake test` not run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/.github/functional_tests/lake_init_failure/action.yml
+++ b/.github/functional_tests/lake_init_failure/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: verify `lake test` didn't run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/.github/functional_tests/lake_init_success/action.yml
+++ b/.github/functional_tests/lake_init_success/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: verify `lake test` didn't run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/.github/functional_tests/subdirectory_lake_package/action.yml
+++ b/.github/functional_tests/subdirectory_lake_package/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: verify `lake test` didn't run
       env:
         OUTPUT_NAME: "test-status"
-        EXPECTED_VALUE: "NOT_RUN"
+        EXPECTED_VALUE: ""
         ACTUAL_VALUE: ${{ steps.lean-action.outputs.test-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- use empty string as default value for status outputs instead of "NOT_RUN"
+to avoid `set-output-parameters` final step breaking log group expansion
+
 ### Fixed
 
 - correct typo of in configuration step: "lake check-test failed" -> "lake check-lint failed"
+- fix log group expansion in failing steps due to `set-output-parameters` step
 
 ## v1.0.1 - 2024-8-24
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,13 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 `lean-action` provides the following output parameters for downstream steps:
 
 - `build-status`
-  - Values: "SUCCESS" | "FAILURE" | "NOT_RUN"
+  - Values: "SUCCESS" | "FAILURE" | ""
 - `test-status`
-  - Values: "SUCCESS" | "FAILURE" | "NOT_RUN"
+  - Values: "SUCCESS" | "FAILURE" | ""
+- `lint-status`
+  - Values: "SUCCESS" | "FAILURE" | ""
+
+Note, a value of empty string indicates `lean-action` did not run the corresponding feature.
 
 ### Example: Use `test-status` output parameter in downstream step
 

--- a/action.yml
+++ b/action.yml
@@ -94,12 +94,12 @@ outputs:
     description: |
       The status of the `lake test` step.
       Allowed values: "SUCCESS" | "FAILURE" | "".
-    value: ${{ steps.set-output-parameters.outputs.test-status }}
+    value: ${{ steps.test.outputs.test-status }}
   lint-status:
     description: |
       The status of the `lake lint` step.
       Allowed values: "SUCCESS" | "FAILURE" | "".
-    value: ${{ steps.set-output-parameters.outputs.lint-status }}
+    value: ${{ steps.lint.outputs.lint-status }}
   detected-mathlib:
     description: |
       If lean-action detected a mathlib dependency equals "true"

--- a/action.yml
+++ b/action.yml
@@ -88,8 +88,8 @@ outputs:
   build-status:
     description: |
       The status of the `lake build` step.
-      Allowed values: "SUCCESS" | "FAILURE" | "NOT_RUN".
-    value: ${{ steps.set-output-parameters.outputs.build-status }}
+      Allowed values: "SUCCESS" | "FAILURE" | "".
+    value: ${{ steps.build.outputs.build-status }}
   test-status:
     description: |
       The status of the `lake test` step.

--- a/action.yml
+++ b/action.yml
@@ -214,17 +214,3 @@ runs:
         ${{ github.action_path }}/scripts/run_lean4checker.sh
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
-
-    # This step sets the output parameters for the entirety of `lean-action`
-    # based on the outputs of the previous steps
-    - name: set output parameters
-      id: set-output-parameters
-      if: always() # always run this step even if previous steps fail
-      env:
-        BUILD_STATUS: ${{ steps.build.outputs.build-status }}
-        TEST_STATUS: ${{ steps.test.outputs.test-status }}
-        LINT_STATUS: ${{ steps.lint.outputs.lint-status }}
-      run: |
-        : Set Output Parameters
-        ${{ github.action_path }}/scripts/set_output_parameters.sh
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -93,12 +93,12 @@ outputs:
   test-status:
     description: |
       The status of the `lake test` step.
-      Allowed values: "SUCCESS" | "FAILURE" | "NOT_RUN".
+      Allowed values: "SUCCESS" | "FAILURE" | "".
     value: ${{ steps.set-output-parameters.outputs.test-status }}
   lint-status:
     description: |
       The status of the `lake lint` step.
-      Allowed values: "SUCCESS" | "FAILURE" | "NOT_RUN".
+      Allowed values: "SUCCESS" | "FAILURE" | "".
     value: ${{ steps.set-output-parameters.outputs.lint-status }}
   detected-mathlib:
     description: |


### PR DESCRIPTION
The final `set-output-parameters` step which was set to run `if: always()` was breaking the automatic expansion of the log groups. Remove this step and update the tests to use the default, empty string, value of the outputs to determine if the step wasn't run.