### PR TITLE
fix: only end log group if lake command succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to avoid `set-output-parameters` final step breaking log group expansion
 
 - correct typo of in configuration step: "lake check-test failed" -> "lake check-lint failed"
 - fix log group expansion in failing steps due to `set-output-parameters` step
+and removing the end log group command when a step fails
 
 ## v1.0.1 - 2024-8-24
 

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -10,13 +10,13 @@ handle_exit() {
     exit_status=$?
     if [ $exit_status -ne 0 ]; then
         echo "build-status=FAILURE" >>"$GITHUB_OUTPUT"
+        echo "::error:: lake build failed"
     else
         echo "build-status=SUCCESS" >>"$GITHUB_OUTPUT"
+        # end log group and add a new line to improve readabiltiy
+        echo "::endgroup::"
+        echo
     fi
-
-    # end log group and add a new line to improve readabiltiy
-    echo "::endgroup::"
-    echo
 }
 
 trap handle_exit EXIT

--- a/scripts/lake_lint.sh
+++ b/scripts/lake_lint.sh
@@ -9,11 +9,12 @@ handle_exit() {
     exit_status=$?
     if [ $exit_status -ne 0 ]; then
         echo "lint-status=FAILURE" >>"$GITHUB_OUTPUT"
+        echo "::error:: lake lint failed"
     else
         echo "lint-status=SUCCESS" >>"$GITHUB_OUTPUT"
+        echo "::endgroup::"
+        echo
     fi
-    echo "::endgroup::"
-    echo
 }
 
 trap handle_exit EXIT

--- a/scripts/lake_test.sh
+++ b/scripts/lake_test.sh
@@ -9,11 +9,11 @@ handle_exit() {
     exit_status=$?
     if [ $exit_status -ne 0 ]; then
         echo "test-status=FAILURE" >>"$GITHUB_OUTPUT"
+        echo "::error:: lake test failed"
     else
         echo "test-status=SUCCESS" >>"$GITHUB_OUTPUT"
+        echo "::endgroup::"
     fi
-    echo "::endgroup::"
-    echo
 }
 
 trap handle_exit EXIT


### PR DESCRIPTION
Ending the log group when a lake command fails prevented the log group from expanding on a command failure.

Related to #92 