### PR TITLE
fix: replace `actions/cache` with `actions/cache/restore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- replace `actions/cache` with `actions/cache/restore` to prevent redundant cache saving
+previously caused by the combination of `actions/cache` and `actions/cache/save`
+
 ## v1.0.2 - 2024-8-26
 
 ### Changed

--- a/action.yml
+++ b/action.yml
@@ -129,7 +129,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: ${{ inputs.lake-package-directory }}/.lake


### PR DESCRIPTION
Calling `actions/cache` in combination with `actions/cache/save` caused redundant cache saves resulting in post-run error messages. `actions/cache/restore` doesn't result in a post-run cache save.

Closes #96 