### PR TITLE
fix: use `eval` to expand `lake build` arguments

### DIFF
--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -21,4 +21,7 @@ handle_exit() {
 
 trap handle_exit EXIT
 
+echo "Build args:"
+echo "$BUILD_ARGS"
+
 lake build "$BUILD_ARGS"

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -24,4 +24,5 @@ trap handle_exit EXIT
 echo "Build args:"
 echo "$BUILD_ARGS"
 
-lake build "$BUILD_ARGS"
+# use eval to ensure build arguments are expanded
+eval "lake build $BUILD_ARGS"

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -21,8 +21,5 @@ handle_exit() {
 
 trap handle_exit EXIT
 
-echo "Build args:"
-echo "$BUILD_ARGS"
-
 # use eval to ensure build arguments are expanded
 eval "lake build $BUILD_ARGS"


### PR DESCRIPTION
Fix the `lake_build.sh` script to expand the arguments to `lake build` with the `eval` command.

Previously, passing multiple arguments to `lake build` via the `build-args` configuration input caused errors
because the `lake_build.sh` script passed all the arguments as one string.

Closes #108 