### PR TITLE
feat: reinstall transient `lean4-pr-releases` toolchains

### DIFF
--- a/.github/functional_tests/reinstall-transient-toolchain/action.yml
+++ b/.github/functional_tests/reinstall-transient-toolchain/action.yml
@@ -1,0 +1,70 @@
+name: 'Reinstall Transient Toolchain Functional Test'
+description: |
+  Run `lean-action` with `reinstall-transient-toolchain: true`.
+  Verify that the toolchain will be redownloaded.
+inputs:
+  toolchain:
+    description: 'Toolchain to use for `lake init` (not the toolchain that will be tested for reinstallation).'
+    required: true
+runs: 
+  using: 'composite'
+  steps:
+    # TODO: once `lean-action` supports just setup, use it here
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: create lake package
+      run: |
+        lake init transienttoolchain .lean
+        lake update
+      shell: bash
+
+    - name: set a toolchain
+      run: |
+        echo "leanprover/lean4-pr-releases:pr-release-6627" > lean-toolchain
+      shell: bash
+
+    - name: "run `lean-action` to install the toolchain"
+      id: lean-action-install
+      uses: ./
+      with:
+        auto-config: true
+        use-github-cache: false
+
+    - name: verify the toolchain is installed
+      run: |
+        elan toolchain list | grep -qFx "leanprover/lean4-pr-releases:pr-release-6627"
+      shell: bash
+
+    - name: verify `lean-action` outcome success
+      env:
+        OUTPUT_NAME: "lean-action-install.outcome"
+        EXPECTED_VALUE: "success"
+        ACTUAL_VALUE: ${{ steps.lean-action-install.outcome }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    - name: "run `lean-action` to uninstall the toolchain"
+      id: lean-action-uninstall
+      uses: ./
+      with:
+        reinstall-transient-toolchain: true
+        auto-config: false
+        use-github-cache: false
+
+    - name: verify the toolchain is no longer installed
+      run: |
+        ! elan toolchain list | grep -qFx "leanprover/lean4-pr-releases:pr-release-6627"
+      shell: bash
+
+    - name: verify `lean-action` outcome success
+      env:
+        OUTPUT_NAME: "lean-action.outcome"
+        EXPECTED_VALUE: "success"
+        ACTUAL_VALUE: ${{ steps.lean-action-uninstall.outcome }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -126,6 +126,14 @@ jobs:
         with:
           toolchain: ${{ env.toolchain }}
 
+  reinstall-transient-toolchain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/functional_tests/reinstall-transient-toolchain
+        with:
+          toolchain: ${{ env.toolchain }}
+
   macos-runner:
     runs-on: macos-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- add option to reinstall `lean4-pr-releases` toolchains, ensuring CI runs with thev latest version
+
 ## v1.1.2 - 2025-03-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Allowed values: a valid directory containing a Lake package.
     # If lake-package-directory is not provided, `lean-action` will use the root directory of the repository by default.
     lake-package-directory: ""
+
+    # Always reinstall the Lean toolchain if it is a transient one, hosted on the lean4-pr-releases repository.
+    # This ensures that CI always uses the latest build of that toolchain.
+    # This setting only applies to `lean4-pr-releases/pr-release-XXXX` toolchains:
+    # regular Lean toolchain releases remain cached.
+    # The toolchain version is determined from the `lean-toolchain` file.
+    # Allowed values: "true" | "false".
+    # Default: "false"
+    reinstall-transient-toolchain: ""
 ```
 
 ## Output Parameters

--- a/action.yml
+++ b/action.yml
@@ -84,6 +84,13 @@ inputs:
       If lake-package-directory is not provided, `lean-action` will use the root directory of the repository by default.
     required: false
     default: "."
+  reinstall-transient-toolchain:
+    description: |
+      When the `lean-toolchain` file specifies a `lean-pr-release` toolchain, uninstall it before running any `lake` commands.
+      This ensures the latest build of the toolchain will be downloaded and used to run CI steps.
+      Allowed values: "true" | "false".
+    required: false
+    default: "false"
 outputs:
   build-status:
     description: |
@@ -126,6 +133,17 @@ runs:
       run: |
         : Configure Lean Action
         ${GITHUB_ACTION_PATH}/scripts/config.sh
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+
+    - name: reinstall transient toolchain
+      if: ${{ inputs.reinstall-transient-toolchain == 'true' }}
+      run: |
+        : Reinstall Transient Toolchains
+        if [[ "$(cat lean-toolchain)" =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
+          printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
+          elan toolchain uninstall "$(cat lean-toolchain)"
+        fi
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
 


### PR DESCRIPTION
This PR adds the option to check if the current toolchain is a transient one hosted on the lean4-pr-releases repository. If so, `lean-action` will remove the old version of the toolchain. This ensures a fresh version of the toolchain is always used to run CI.

This is an important step in many Mathlib CI workflows, and adding it to this action would allow us to switch some custom workflows over to run mostly via `lean-action`.