### PR TITLE
feat: option for running lake exe mk_all --check

### DIFF
--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -1,0 +1,51 @@
+name: '`mk_all` test'
+description: 'Run `lake exe mk_all --check` twice and verify that it fails before `lake exe mk_all`, and succeeds afterwards.'
+inputs:
+  toolchain:
+    description: 'Toolchain to use for the test'
+    required: true
+runs: 
+  using: 'composite'
+  steps:
+    # TODO: once `lean-action` supports just setup, use it here
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: create lake package with an unimported file
+      run: |
+        lake init mkall math
+        lake update
+        echo "def foo := 1" > Mkall/Foo.lean
+      shell: bash
+
+    - name: "run `lean-action`"
+      id: lean-action
+      uses: ./
+      with:
+        use-github-cache: false
+        mk_all-check: true
+
+    - name: verify `lake exe mk_all --check` failure
+      env:
+        OUTPUT_NAME: "mk_all-status"
+        EXPECTED_VALUE: "FAILURE"
+        ACTUAL_VALUE: ${{ steps.lean-action.outputs.mk_all-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    - name: "run `lake exe mk_all` to fix the issue"
+      run: |
+        lake exe mk_all
+      shell: bash
+
+    - name: verify `lake exe mk_all --check` success
+      env:
+        OUTPUT_NAME: "mk_all-status"
+        EXPECTED_VALUE: "SUCCESS"
+        ACTUAL_VALUE: ${{ steps.lean-action.outputs.mk_all-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash

--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -25,6 +25,7 @@ runs:
     - name: "run `lean-action`"
       id: lean-action
       uses: ./
+      continue-on-error: true # required so that the action does not fail the workflow
       with:
         use-github-cache: false
         mk_all-check: true

--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -44,6 +44,14 @@ runs:
       continue-on-error: true # mk_all returns 1 if it made changes; this is not an error here.
       shell: bash
 
+    - name: "rerun `lean-action`"
+      id: lean-action
+      uses: ./
+      continue-on-error: true # required so that the action does not fail the workflow
+      with:
+        use-github-cache: false
+        mk_all-check: true
+
     - name: verify `lake exe mk_all --check` success
       env:
         OUTPUT_NAME: "mk_all-status"

--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: bash
 
     - name: "rerun `lean-action`"
-      id: lean-action
+      id: lean-action-rerun
       uses: ./
       continue-on-error: true # required so that the action does not fail the workflow
       with:
@@ -56,6 +56,6 @@ runs:
       env:
         OUTPUT_NAME: "mk_all-status"
         EXPECTED_VALUE: "SUCCESS"
-        ACTUAL_VALUE: ${{ steps.lean-action.outputs.mk_all-status }}
+        ACTUAL_VALUE: ${{ steps.lean-action-rerun.outputs.mk_all-status }}
       run: .github/functional_tests/test_helpers/verify_action_output.sh
       shell: bash

--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -41,6 +41,7 @@ runs:
     - name: "run `lake exe mk_all` to fix the issue"
       run: |
         lake exe mk_all
+      continue-on-error: true # mk_all returns 1 if it made changes; this is not an error here.
       shell: bash
 
     - name: verify `lake exe mk_all --check` success

--- a/.github/functional_tests/mk_all-check/action.yml
+++ b/.github/functional_tests/mk_all-check/action.yml
@@ -47,7 +47,6 @@ runs:
     - name: "rerun `lean-action`"
       id: lean-action-rerun
       uses: ./
-      continue-on-error: true # required so that the action does not fail the workflow
       with:
         use-github-cache: false
         mk_all-check: true

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -134,6 +134,14 @@ jobs:
         with:
           toolchain: ${{ env.toolchain }}
 
+  mk_all-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/functional_tests/mk_all-check
+        with:
+          toolchain: ${{ env.toolchain }}
+
   macos-runner:
     runs-on: macos-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Allowed values: "true" | "false" | "default".
     lint: ""
 
+    # Check all files are imported with `lake exe mk_all --check`.
+    # Allowed values: "true" | "false".
+    mk_all-check: ""
+
     # Build arguments to pass to `lake build {build-args}`.
     # For example, `build-args: "--quiet"` will run `lake build --quiet`.
     # By default, `lean-action` calls `lake build` with no arguments.
@@ -222,6 +226,8 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 - `test-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 - `lint-status`
+  - Values: "SUCCESS" | "FAILURE" | ""
+- `mk_all-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 
 Note, a value of empty string indicates `lean-action` did not run the corresponding feature.

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
       Allowed values: "true" | "false" | "default".
     required: false
     default: "default"
-  mk-all_check:
+  mk_all-check:
     description: |
       Check all files are imported with `lake exe mk_all --check`.
       Allowed values: "true" | "false"

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ inputs:
       Allowed values: "true" | "false" | "default".
     required: false
     default: "default"
+  mk-all_check:
+    description: |
+      Check all files are imported with `lake exe mk_all --check`.
+      Allowed values: "true" | "false"
+    required: false
+    default: "false"
   build-args:
     description: |
       Build arguments to pass to `lake build {build-args}`.
@@ -107,6 +113,11 @@ outputs:
       The status of the `lake lint` step.
       Allowed values: "SUCCESS" | "FAILURE" | "".
     value: ${{ steps.lint.outputs.lint-status }}
+  mk_all-status:
+    description: |
+      The status of the `lake exe mk_all --check` step.
+      Allowed values: "SUCCESS" | "FAILURE" | "".
+    value: ${{ steps.mk_all.outputs.mk_all-status }}
   detected-mathlib:
     description: |
       If lean-action detected a mathlib dependency equals "true"
@@ -144,6 +155,15 @@ runs:
           printf 'Uninstalling transient toolchain %s\n' "$(cat lean-toolchain)"
           elan toolchain uninstall "$(cat lean-toolchain)"
         fi
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+
+    - name: ensure all files are imported
+      id: mk_all
+      if: ${{ inputs.mk_all-check == 'true'}}
+      run: |
+        : Ensure all files are imported
+        ${GITHUB_ACTION_PATH}/scripts/mk_all_check.sh
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
 

--- a/scripts/mk_all_check.sh
+++ b/scripts/mk_all_check.sh
@@ -4,7 +4,7 @@ set -e
 echo "::group::mk_all Output"
 
 # handle_exit function to handle the exit status of the script
-# and set the test-status output parameter accordingly
+# and set the mk_all-status output parameter accordingly
 handle_exit() {
     exit_status=$?
     if [ $exit_status -ne 0 ]; then

--- a/scripts/mk_all_check.sh
+++ b/scripts/mk_all_check.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "::group::mk_all Output"
+
+# handle_exit function to handle the exit status of the script
+# and set the test-status output parameter accordingly
+handle_exit() {
+    exit_status=$?
+    if [ $exit_status -ne 0 ]; then
+        echo "mk_all-status=FAILURE" >>"$GITHUB_OUTPUT"
+        echo "::error:: lake exe mk_all failed"
+    else
+        echo "mk_all-status=SUCCESS" >>"$GITHUB_OUTPUT"
+        echo "::endgroup::"
+    fi
+}
+
+trap handle_exit EXIT
+
+lake exe mk_all --check


### PR DESCRIPTION
This command checks that all files in the default target's directory are imported in the main file. In repositories such as FLT, this check is run before other build steps, to ensure every relevant file is built, but it must be run after Elan has been initialized. So to use `lean-action` in FLT, we would like to incorporate the mk_all check as a step.