### PR TITLE
feat: add nanoda external type checker support

### DIFF
--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -76,13 +76,19 @@ jobs:
             });
 
       - name: Send webhook notification
-        if: always() && inputs.notify == 'webhook' && secrets.webhook-url != ''
+        if: always() && inputs.notify == 'webhook'
+        env:
+          WEBHOOK_URL: ${{ secrets.webhook-url }}
         run: |
+          if [ -z "$WEBHOOK_URL" ]; then
+            echo "::error::webhook-url secret is required when notify is set to 'webhook'"
+            exit 1
+          fi
           STATUS="${{ job.status }}"
           EMOJI=$([[ "$STATUS" == "success" ]] && echo "✅" || echo "❌")
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          curl -X POST "${{ secrets.webhook-url }}" \
+          curl -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{
               \"text\": \"$EMOJI nanoda daily verification: $STATUS\",
@@ -99,7 +105,7 @@ jobs:
         shell: bash
 
       - name: Send Zulip notification on success
-        if: success() && inputs.notify == 'zulip' && secrets.zulip-api-key != ''
+        if: success() && inputs.notify == 'zulip'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
         with:
           api-key: ${{ secrets.zulip-api-key }}
@@ -112,7 +118,7 @@ jobs:
             ✅ nanoda daily verification [succeeded](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on `${{ github.sha }}`
 
       - name: Send Zulip notification on failure
-        if: failure() && inputs.notify == 'zulip' && secrets.zulip-api-key != ''
+        if: failure() && inputs.notify == 'zulip'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
         with:
           api-key: ${{ secrets.zulip-api-key }}

--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -1,0 +1,125 @@
+# Reusable workflow for daily nanoda verification
+# Users can call this workflow from their repository:
+#
+#   name: Daily nanoda verification
+#   on:
+#     schedule:
+#       - cron: '0 0 * * *'
+#     workflow_dispatch:
+#   jobs:
+#     verify:
+#       uses: leanprover/lean-action/.github/workflows/nanoda-daily.yml@v1
+#       secrets:
+#         webhook-url: ${{ secrets.WEBHOOK_URL }}      # optional
+#         zulip-api-key: ${{ secrets.ZULIP_API_KEY }}  # optional
+
+name: nanoda Daily Verification
+
+on:
+  workflow_call:
+    inputs:
+      allow-sorry:
+        description: 'Permit sorryAx axiom'
+        type: boolean
+        default: true
+      notify:
+        description: 'Notification method: issue, webhook, zulip, none'
+        type: string
+        default: 'issue'
+      zulip-stream:
+        description: 'Zulip stream name (if using zulip notify)'
+        type: string
+        default: 'ci'
+      zulip-topic:
+        description: 'Zulip topic (if using zulip notify)'
+        type: string
+        default: 'nanoda'
+      zulip-org-url:
+        description: 'Zulip organization URL (required if using zulip notify)'
+        type: string
+        default: ''
+    secrets:
+      webhook-url:
+        description: 'Slack/Discord webhook URL (optional)'
+        required: false
+      zulip-api-key:
+        description: 'Zulip bot API key (optional)'
+        required: false
+
+jobs:
+  nanoda-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run lean-action with nanoda
+        id: lean-action
+        uses: leanprover/lean-action@v1
+        with:
+          nanoda: true
+          nanoda-allow-sorry: ${{ inputs.allow-sorry }}
+          nanoda-on-main-only: false  # This workflow is already scheduled, so run always
+
+      - name: Create GitHub issue on failure
+        if: failure() && inputs.notify == 'issue'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '❌ Daily nanoda verification failed',
+              body: `The daily nanoda type checker verification failed.\n\n**Commit:** ${context.sha}\n**Run:** [View workflow run](${runUrl})\n\nPlease investigate and fix any type checking issues.`,
+              labels: ['nanoda', 'automated', 'ci-failure']
+            });
+
+      - name: Send webhook notification
+        if: always() && inputs.notify == 'webhook' && secrets.webhook-url != ''
+        run: |
+          STATUS="${{ job.status }}"
+          EMOJI=$([[ "$STATUS" == "success" ]] && echo "✅" || echo "❌")
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          curl -X POST "${{ secrets.webhook-url }}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"text\": \"$EMOJI nanoda daily verification: $STATUS\",
+              \"blocks\": [
+                {
+                  \"type\": \"section\",
+                  \"text\": {
+                    \"type\": \"mrkdwn\",
+                    \"text\": \"$EMOJI *nanoda daily verification*: $STATUS\n<$RUN_URL|View run> | Commit: \`${{ github.sha }}\`\"
+                  }
+                }
+              ]
+            }"
+        shell: bash
+
+      - name: Send Zulip notification on success
+        if: success() && inputs.notify == 'zulip' && secrets.zulip-api-key != ''
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.zulip-api-key }}
+          email: 'github-bot@${{ inputs.zulip-org-url }}'
+          organization-url: 'https://${{ inputs.zulip-org-url }}'
+          to: ${{ inputs.zulip-stream }}
+          type: 'stream'
+          topic: ${{ inputs.zulip-topic }}
+          content: |
+            ✅ nanoda daily verification [succeeded](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on `${{ github.sha }}`
+
+      - name: Send Zulip notification on failure
+        if: failure() && inputs.notify == 'zulip' && secrets.zulip-api-key != ''
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.zulip-api-key }}
+          email: 'github-bot@${{ inputs.zulip-org-url }}'
+          organization-url: 'https://${{ inputs.zulip-org-url }}'
+          to: ${{ inputs.zulip-stream }}
+          type: 'stream'
+          topic: '${{ inputs.zulip-topic }} failure'
+          content: |
+            ❌ nanoda daily verification [failed](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on `${{ github.sha }}`

--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -87,7 +87,7 @@ jobs:
           EMOJI=$([[ "$STATUS" == "success" ]] && echo "✅" || echo "❌")
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          curl -X POST "$WEBHOOK_URL" \
+          curl --fail -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d "{
               \"text\": \"$EMOJI nanoda daily verification: $STATUS\",
@@ -104,7 +104,7 @@ jobs:
         shell: bash
 
       - name: Validate Zulip configuration
-        if: inputs.notify == 'zulip'
+        if: always() && inputs.notify == 'zulip'
         env:
           ZULIP_ORG_URL: ${{ inputs.zulip-org-url }}
           ZULIP_API_KEY: ${{ secrets.zulip-api-key }}

--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -59,7 +59,6 @@ jobs:
         with:
           nanoda: true
           nanoda-allow-sorry: ${{ inputs.allow-sorry }}
-          nanoda-on-main-only: false  # This workflow is already scheduled, so run always
 
       - name: Create GitHub issue on failure
         if: failure() && inputs.notify == 'issue'

--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -103,6 +103,21 @@ jobs:
             }"
         shell: bash
 
+      - name: Validate Zulip configuration
+        if: inputs.notify == 'zulip'
+        env:
+          ZULIP_ORG_URL: ${{ inputs.zulip-org-url }}
+          ZULIP_API_KEY: ${{ secrets.zulip-api-key }}
+        run: |
+          if [ -z "$ZULIP_ORG_URL" ]; then
+            echo "::error::zulip-org-url input is required when notify is set to 'zulip'"
+            exit 1
+          fi
+          if [ -z "$ZULIP_API_KEY" ]; then
+            echo "::error::zulip-api-key secret is required when notify is set to 'zulip'"
+            exit 1
+          fi
+
       - name: Send Zulip notification on success
         if: success() && inputs.notify == 'zulip'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/nanoda-daily.yml
+++ b/.github/workflows/nanoda-daily.yml
@@ -104,7 +104,9 @@ jobs:
         shell: bash
 
       - name: Validate Zulip configuration
-        if: always() && inputs.notify == 'zulip'
+        id: validate-zulip
+        if: (success() || failure()) && inputs.notify == 'zulip'
+        continue-on-error: true
         env:
           ZULIP_ORG_URL: ${{ inputs.zulip-org-url }}
           ZULIP_API_KEY: ${{ secrets.zulip-api-key }}
@@ -119,7 +121,7 @@ jobs:
           fi
 
       - name: Send Zulip notification on success
-        if: success() && inputs.notify == 'zulip'
+        if: success() && inputs.notify == 'zulip' && steps.validate-zulip.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
         with:
           api-key: ${{ secrets.zulip-api-key }}
@@ -132,7 +134,7 @@ jobs:
             ✅ nanoda daily verification [succeeded](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) on `${{ github.sha }}`
 
       - name: Send Zulip notification on failure
-        if: failure() && inputs.notify == 'zulip'
+        if: steps.lean-action.outcome == 'failure' && inputs.notify == 'zulip' && steps.validate-zulip.outcome == 'success'
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
         with:
           api-key: ${{ secrets.zulip-api-key }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new `nanoda` input to check environment with [nanoda](https://github.com/ammkrn/nanoda_lib) external type checker
 - new `nanoda-allow-sorry` input to permit sorryAx axiom when running nanoda (default: true)
-- new `nanoda-on-main-only` input to run nanoda only on push to main branch (default: true)
 - new `nanoda-status` output parameter
 - new reusable workflow `nanoda-daily.yml` for scheduled daily verification with notifications
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- new `nanoda` input to check environment with [nanoda](https://github.com/ammkrn/nanoda_lib) external type checker
+- new `nanoda-allow-sorry` input to permit sorryAx axiom when running nanoda (default: true)
+- new `nanoda-on-main-only` input to run nanoda only on push to main branch (default: true)
+- new `nanoda-status` output parameter
+- new reusable workflow `nanoda-daily.yml` for scheduled daily verification with notifications
+
 ### Changed
 
 - rename the `lean4checker` input to `leanchecker`, while keeping `lean4checker` as a deprecated alias

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If `lean-action` is unable to successfully run the step, `lean-action` will fail
 - `mk_all-check`
 - `check-reservoir-eligibility`
 - `leanchecker`
+- `nanoda`
 
 ### Automatic configuration
 
@@ -204,7 +205,26 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 
     # Deprecated alias for `leanchecker`.
     lean4checker: ""
-    
+
+    # Check environment with nanoda external type checker.
+    # nanoda is an independent Lean 4 type checker written in Rust.
+    # Requires Rust toolchain (will be installed automatically if not present).
+    # Allowed values: "true" | "false".
+    # Default: "false"
+    nanoda: ""
+
+    # When running nanoda, permit the sorryAx axiom.
+    # Set to "false" if your project should have no sorry placeholders.
+    # Allowed values: "true" | "false".
+    # Default: "true"
+    nanoda-allow-sorry: ""
+
+    # Only run nanoda on push events to the default branch, not on pull requests.
+    # Useful for reducing CI time on PRs since nanoda verification is slow.
+    # Allowed values: "true" | "false".
+    # Default: "true"
+    nanoda-on-main-only: ""
+
     # Enable GitHub caching.
     # Allowed values: "true" or "false".
     # If use-github-cache input is not provided, the action will use GitHub caching by default.
@@ -237,6 +257,8 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 - `lint-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 - `mk_all-status`
+  - Values: "SUCCESS" | "FAILURE" | ""
+- `nanoda-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 
 Note, a value of empty string indicates `lean-action` did not run the corresponding feature.
@@ -300,6 +322,69 @@ steps:
     run: |
       lake exe graph
       rm import_graph.dot
+```
+
+## External Type Checking with nanoda
+
+[nanoda](https://github.com/ammkrn/nanoda_lib) is an independent Lean 4 type checker written in Rust. It provides additional assurance that your project's declarations are well-typed by verifying them with a completely separate implementation.
+
+### Enable nanoda verification
+
+```yaml
+- uses: leanprover/lean-action@v1
+  with:
+    nanoda: true
+```
+
+By default, nanoda only runs on push events to the main branch (not on PRs) because verification adds significant CI time. To run on all events:
+
+```yaml
+- uses: leanprover/lean-action@v1
+  with:
+    nanoda: true
+    nanoda-on-main-only: false
+```
+
+### Require no sorry placeholders
+
+By default, nanoda permits the `sorryAx` axiom for projects with incomplete proofs. To require all proofs be complete:
+
+```yaml
+- uses: leanprover/lean-action@v1
+  with:
+    nanoda: true
+    nanoda-allow-sorry: false
+```
+
+### Daily nanoda verification with notifications
+
+For daily verification runs with automatic failure notifications, use the reusable workflow:
+
+```yaml
+# .github/workflows/nanoda-daily.yml
+name: Daily nanoda verification
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  verify:
+    uses: leanprover/lean-action/.github/workflows/nanoda-daily.yml@v1
+    # Optional: configure notification method
+    # with:
+    #   notify: 'issue'  # default: creates GitHub issue on failure
+    # For webhook (Slack/Discord):
+    # with:
+    #   notify: 'webhook'
+    # secrets:
+    #   webhook-url: ${{ secrets.WEBHOOK_URL }}
+    # For Zulip:
+    # with:
+    #   notify: 'zulip'
+    #   zulip-org-url: 'leanprover.zulipchat.com'
+    # secrets:
+    #   zulip-api-key: ${{ secrets.ZULIP_API_KEY }}
 ```
 
 ## Projects which use `lean-action`

--- a/README.md
+++ b/README.md
@@ -219,12 +219,6 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Default: "true"
     nanoda-allow-sorry: ""
 
-    # Only run nanoda on push events to the default branch, not on pull requests.
-    # Useful for reducing CI time on PRs since nanoda verification is slow.
-    # Allowed values: "true" | "false".
-    # Default: "true"
-    nanoda-on-main-only: ""
-
     # Enable GitHub caching.
     # Allowed values: "true" or "false".
     # If use-github-cache input is not provided, the action will use GitHub caching by default.
@@ -334,15 +328,6 @@ steps:
 - uses: leanprover/lean-action@v1
   with:
     nanoda: true
-```
-
-By default, nanoda only runs on push events to the main branch (not on PRs) because verification adds significant CI time. To run on all events:
-
-```yaml
-- uses: leanprover/lean-action@v1
-  with:
-    nanoda: true
-    nanoda-on-main-only: false
 ```
 
 ### Require no sorry placeholders

--- a/action.yml
+++ b/action.yml
@@ -106,13 +106,6 @@ inputs:
       Allowed values: "true" | "false".
     required: false
     default: "true"
-  nanoda-on-main-only:
-    description: |
-      Only run nanoda on push events to the default branch, not on pull requests.
-      Useful for reducing CI time on PRs since nanoda verification is slow.
-      Allowed values: "true" | "false".
-    required: false
-    default: "true"
   use-github-cache:
     description: |
       Enable GitHub caching.
@@ -301,7 +294,7 @@ runs:
 
     - name: check environment with nanoda
       id: nanoda
-      if: ${{ inputs.nanoda == 'true' && (inputs.nanoda-on-main-only != 'true' || github.event_name == 'push') }}
+      if: ${{ inputs.nanoda == 'true' }}
       env:
         NANODA_ALLOW_SORRY: ${{ inputs.nanoda-allow-sorry }}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,28 @@ inputs:
       Allowed values: "true" | "false".
     required: false
     default: "false"
+  nanoda:
+    description: |
+      Check environment with nanoda external type checker.
+      nanoda is an independent Lean 4 type checker written in Rust.
+      Requires Rust toolchain (will be installed automatically if not present).
+      Allowed values: "true" | "false".
+    required: false
+    default: "false"
+  nanoda-allow-sorry:
+    description: |
+      When running nanoda, permit the sorryAx axiom.
+      Set to "false" if your project should have no sorry placeholders.
+      Allowed values: "true" | "false".
+    required: false
+    default: "true"
+  nanoda-on-main-only:
+    description: |
+      Only run nanoda on push events to the default branch, not on pull requests.
+      Useful for reducing CI time on PRs since nanoda verification is slow.
+      Allowed values: "true" | "false".
+    required: false
+    default: "true"
   use-github-cache:
     description: |
       Enable GitHub caching.
@@ -138,6 +160,11 @@ outputs:
       If lean-action detected a mathlib dependency equals "true"
       otherwise equals "false".
     value: ${{ steps.detect-mathlib.outputs.detected-mathlib }}
+  nanoda-status:
+    description: |
+      The status of the nanoda check step.
+      Allowed values: "SUCCESS" | "FAILURE" | "".
+    value: ${{ steps.nanoda.outputs.nanoda-status }}
 
 runs:
   using: "composite"
@@ -269,5 +296,16 @@ runs:
       run: |
         : Check Environment with leanchecker
         ${GITHUB_ACTION_PATH}/scripts/run_leanchecker.sh
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+
+    - name: check environment with nanoda
+      id: nanoda
+      if: ${{ inputs.nanoda == 'true' && (inputs.nanoda-on-main-only != 'true' || github.event_name == 'push') }}
+      env:
+        NANODA_ALLOW_SORRY: ${{ inputs.nanoda-allow-sorry }}
+      run: |
+        : Check Environment with nanoda
+        ${GITHUB_ACTION_PATH}/scripts/run_nanoda.sh
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -e
+
+# Group logging using the ::group:: workflow command
+echo "::group::nanoda Output"
+echo "Checking environment with nanoda external type checker"
+
+# handle_exit function to capture exit status
+handle_exit() {
+    exit_status=$?
+    if [ $exit_status -ne 0 ]; then
+        echo "nanoda-status=FAILURE" >> "$GITHUB_OUTPUT"
+        echo "::error::nanoda check failed"
+    else
+        echo "nanoda-status=SUCCESS" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+        echo
+    fi
+}
+trap handle_exit EXIT
+
+# Step 1: Install Rust if not present
+echo "Checking for Rust installation..."
+if ! command -v cargo &> /dev/null; then
+    echo "Installing Rust toolchain..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+else
+    echo "Rust already installed: $(cargo --version)"
+fi
+
+# Step 2: Clone and build lean4export
+echo "Cloning and building lean4export..."
+# TODO: Once https://github.com/leanprover/lean4export/pull/11 is merged,
+# switch to leanprover/lean4export and remove the branch checkout.
+git clone --depth 1 --branch fix-nondep-normalization https://github.com/kim-em/lean4export.git _lean4export
+
+# Copy lean-toolchain to lean4export so it uses matching Lean version
+cp lean-toolchain _lean4export/
+
+(
+    cd _lean4export
+    lake build
+)
+
+# Step 3: Clone and build nanoda_lib
+echo "Cloning and building nanoda_lib..."
+# Using debug branch which has fixes for recent Lean kernel changes
+git clone --depth 1 --branch debug https://github.com/ammkrn/nanoda_lib.git _nanoda_lib
+
+(
+    cd _nanoda_lib
+    cargo build --release
+)
+
+# Step 4: Detect module name from lakefile
+echo "Detecting module name..."
+MODULE_NAME=""
+
+# Try lakefile.toml first
+if [ -f "lakefile.toml" ]; then
+    # Extract name from [package] section
+    MODULE_NAME=$(grep -A5 '^\[package\]' lakefile.toml | grep '^name' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/' || true)
+fi
+
+# Fallback to lakefile.lean
+if [ -z "$MODULE_NAME" ] && [ -f "lakefile.lean" ]; then
+    # Try to extract from 'package' declaration
+    MODULE_NAME=$(grep -E "^package\s+" lakefile.lean | head -1 | awk '{print $2}' || true)
+fi
+
+if [ -z "$MODULE_NAME" ]; then
+    echo "::error::Could not detect module name from lakefile.toml or lakefile.lean"
+    exit 1
+fi
+
+echo "Detected module name: $MODULE_NAME"
+
+# Step 5: Export the project
+echo "Exporting $MODULE_NAME..."
+EXPORT_FILE="_nanoda_export.txt"
+lake env _lean4export/.lake/build/bin/lean4export "$MODULE_NAME" > "$EXPORT_FILE"
+
+echo "Export file size: $(wc -c < "$EXPORT_FILE") bytes"
+echo "Export file lines: $(wc -l < "$EXPORT_FILE") lines"
+
+# Step 6: Create nanoda config
+echo "Creating nanoda configuration..."
+CONFIG_FILE="_nanoda_config.json"
+
+# Build permitted_axioms array
+PERMITTED_AXIOMS='["propext", "Classical.choice", "Quot.sound", "Lean.trustCompiler"'
+if [ "$NANODA_ALLOW_SORRY" = "true" ]; then
+    PERMITTED_AXIOMS="$PERMITTED_AXIOMS, \"sorryAx\""
+    echo "Note: sorryAx axiom is permitted"
+fi
+PERMITTED_AXIOMS="$PERMITTED_AXIOMS]"
+
+cat > "$CONFIG_FILE" << EOF
+{
+    "export_file_path": "$EXPORT_FILE",
+    "use_stdin": false,
+    "permitted_axioms": $PERMITTED_AXIOMS,
+    "unpermitted_axiom_hard_error": false,
+    "nat_extension": true,
+    "string_extension": true,
+    "print_success_message": true
+}
+EOF
+
+echo "Config file contents:"
+cat "$CONFIG_FILE"
+
+# Step 7: Run nanoda
+echo ""
+echo "Running nanoda type checker..."
+_nanoda_lib/target/release/nanoda_bin "$CONFIG_FILE"
+
+# Cleanup temporary files
+echo ""
+echo "Cleaning up temporary files..."
+rm -rf _lean4export _nanoda_lib "$EXPORT_FILE" "$CONFIG_FILE"
+
+echo "nanoda check completed successfully"

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -69,8 +69,8 @@ fi
 
 # Fallback to lakefile.lean
 if [ -z "$MODULE_NAME" ] && [ -f "lakefile.lean" ]; then
-    # Try to extract from 'package' declaration
-    MODULE_NAME=$(grep -E "^package\s+" lakefile.lean | head -1 | awk '{print $2}' || true)
+    # Try to extract from 'package' declaration (allowing leading whitespace)
+    MODULE_NAME=$(grep -E "^\s*package\s+" lakefile.lean | head -1 | awk '{print $2}' || true)
 fi
 
 if [ -z "$MODULE_NAME" ]; then

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -5,9 +5,14 @@ set -e
 echo "::group::nanoda Output"
 echo "Checking environment with nanoda external type checker"
 
-# handle_exit function to capture exit status
+# handle_exit function to capture exit status and cleanup
 handle_exit() {
     exit_status=$?
+
+    # Always cleanup temporary files/directories
+    echo "Cleaning up temporary files..."
+    rm -rf _lean4export _nanoda_lib _nanoda_export.txt _nanoda_config.json
+
     if [ $exit_status -ne 0 ]; then
         echo "nanoda-status=FAILURE" >> "$GITHUB_OUTPUT"
         echo "::error::nanoda check failed"
@@ -114,10 +119,5 @@ cat "$CONFIG_FILE"
 echo ""
 echo "Running nanoda type checker..."
 _nanoda_lib/target/release/nanoda_bin "$CONFIG_FILE"
-
-# Cleanup temporary files
-echo ""
-echo "Cleaning up temporary files..."
-rm -rf _lean4export _nanoda_lib "$EXPORT_FILE" "$CONFIG_FILE"
 
 echo "nanoda check completed successfully"

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -9,6 +9,9 @@ echo "Checking environment with nanoda external type checker"
 handle_exit() {
     exit_status=$?
 
+    # Close the log group before cleanup
+    echo "::endgroup::"
+
     # Always cleanup temporary files/directories
     echo "Cleaning up temporary files..."
     rm -rf _lean4export _nanoda_lib _nanoda_export.txt _nanoda_config.json
@@ -18,11 +21,16 @@ handle_exit() {
         echo "::error::nanoda check failed"
     else
         echo "nanoda-status=SUCCESS" >> "$GITHUB_OUTPUT"
-        echo "::endgroup::"
         echo
     fi
 }
 trap handle_exit EXIT
+
+# Check for conflicting directories before we start
+if [ -d "_lean4export" ] || [ -d "_nanoda_lib" ]; then
+    echo "::error::Directories _lean4export or _nanoda_lib already exist. Please remove them before running nanoda."
+    exit 1
+fi
 
 # Step 1: Install Rust if not present
 echo "Checking for Rust installation..."

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -32,9 +32,7 @@ fi
 
 # Step 2: Clone and build lean4export
 echo "Cloning and building lean4export..."
-# TODO: Once https://github.com/leanprover/lean4export/pull/11 is merged,
-# switch to leanprover/lean4export and remove the branch checkout.
-git clone --depth 1 --branch fix-nondep-normalization https://github.com/kim-em/lean4export.git _lean4export
+git clone --depth 1 https://github.com/leanprover/lean4export.git _lean4export
 
 # Copy lean-toolchain to lean4export so it uses matching Lean version
 cp lean-toolchain _lean4export/


### PR DESCRIPTION
This PR adds support for verifying Lean projects with [nanoda](https://github.com/ammkrn/nanoda_lib), an independent Lean 4 type checker written in Rust.

## New Inputs

| Input | Default | Description |
|-------|---------|-------------|
| `nanoda` | `"false"` | Enable nanoda verification |
| `nanoda-allow-sorry` | `"true"` | Permit sorryAx axiom |
| `nanoda-on-main-only` | `"true"` | Only run on push to main, not PRs |

## New Output

- `nanoda-status`: `"SUCCESS"` | `"FAILURE"` | `""`

## Reusable Daily Workflow

Also adds `.github/workflows/nanoda-daily.yml` - a reusable workflow for scheduled daily verification with configurable notifications:

```yaml
jobs:
  verify:
    uses: leanprover/lean-action/.github/workflows/nanoda-daily.yml@v1
    # Notifications: issue (default), webhook, zulip, or none
```

## Implementation Notes

- Rust toolchain is installed automatically if not present
- Uses `kim-em/lean4export` fork with fix for nonDep normalization (pending https://github.com/leanprover/lean4export/pull/11)
- Uses `ammkrn/nanoda_lib` debug branch with kernel compatibility fixes

## Testing

Successfully tested on:
- sphere-eversion: 352,154 declarations (~6 min)
- Carleson: 353,613 declarations (~6 min)  
- FLT: 420,742 declarations (~11 min)
- Mathlib: 627,356 declarations (~17 min)

🤖 Prepared with Claude Code