### PR TITLE
fix: update actions/cache to v5 to resolve Node.js 20 deprecation warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -174,7 +174,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
 
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v5
       if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: ${{ inputs.lake-package-directory }}/.lake
@@ -216,7 +216,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}
 
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v5
       if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: ${{ inputs.lake-package-directory }}/.lake


### PR DESCRIPTION
`actions/cache/restore` and `actions/cache/save` `v4` use Node.js 20, which is [deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced cutover to Node.js 24 on June 2nd, 2026). Updated to v5 which runs on Node.js 24. 

This also removes the corresponding deprecation warning that currently appears for all users of this action 

