### PR TITLE
fix: use `lake test` if `test.sh` is missing from lean4checker

### DIFF
--- a/scripts/run_leanchecker.sh
+++ b/scripts/run_leanchecker.sh
@@ -32,7 +32,11 @@ git checkout "$toolchain_version"
 cp ../lean-toolchain .
 
 lake build
-./test.sh
+if [ -f ./test.sh ]; then
+  ./test.sh
+else
+  lake test
+fi
 )
 
 echo "Running external lean4checker"


### PR DESCRIPTION
test.sh was removed in lean4check 4.27.0

note, Lean version >= 4.28.x will use the built in leanchecker so this only affects 4.27.0