### PR TITLE
feat: add `leanchecker-args` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- new `leanchecker-args` input to pass arguments to `lake env leanchecker`,
+  e.g. `leanchecker-args: "-v"` for verbose output or explicit module prefixes
+  such as `leanchecker-args: "MyPkg.Core"` to narrow the set of modules checked
+
 ## v1.5.0 - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Default: "false"
     leanchecker: ""
 
+    # Extra arguments to pass to `lake env leanchecker {leanchecker-args}`.
+    # For example, `leanchecker-args: "-v"` enables verbose output, and
+    # `leanchecker-args: "MyPkg.Core MyPkg.Extras"` restricts checking to the
+    # listed module prefixes. Only takes effect when `leanchecker: true`.
+    # Default: ""
+    leanchecker-args: ""
+
     # Deprecated alias for `leanchecker`.
     lean4checker: ""
 

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,16 @@ inputs:
       Allowed values: "true" | "false".
     required: false
     default: "false"
+  leanchecker-args:
+    description: |
+      Extra arguments to pass to `lake env leanchecker {leanchecker-args}`.
+      For example, `leanchecker-args: "-v"` enables verbose output, and
+      `leanchecker-args: "MyPkg.Core MyPkg.Extras"` restricts checking to the
+      listed module prefixes.
+      By default, `lean-action` calls `lake env leanchecker` with no arguments,
+      which checks every module in the root package.
+    required: false
+    default: ""
   lean4checker:
     description: |
       Deprecated alias for `leanchecker`.
@@ -286,6 +296,7 @@ runs:
       env:
         LEANCHECKER_INPUT: ${{ inputs.leanchecker }}
         LEAN4CHECKER_INPUT: ${{ inputs.lean4checker }}
+        LEANCHECKER_ARGS: ${{ inputs.leanchecker-args }}
       run: |
         : Check Environment with leanchecker
         ${GITHUB_ACTION_PATH}/scripts/run_leanchecker.sh

--- a/scripts/run_leanchecker.sh
+++ b/scripts/run_leanchecker.sh
@@ -11,7 +11,8 @@ fi
 leanchecker_path="$(elan which leanchecker 2>/dev/null || true)"
 if [ -n "$leanchecker_path" ] && [ -x "$leanchecker_path" ]; then
   echo "Using bundled leanchecker from the active Lean toolchain"
-  lake env leanchecker
+  # use eval to ensure leanchecker arguments are expanded
+  eval "lake env leanchecker ${LEANCHECKER_ARGS:-}"
   echo "::endgroup::"
   echo
   exit 0
@@ -40,7 +41,8 @@ fi
 )
 
 echo "Running external lean4checker"
-lake env lean4checker/.lake/build/bin/lean4checker
+# use eval to ensure leanchecker arguments are expanded
+eval "lake env lean4checker/.lake/build/bin/lean4checker ${LEANCHECKER_ARGS:-}"
 
 echo "::endgroup::"
 echo


### PR DESCRIPTION
Adds a `leanchecker-args` input analogous to `build-args` / `test-args`,
whose contents are appended to the `lake env leanchecker` invocation
(both for the bundled toolchain binary and the external `lean4checker`
fallback).

## Motivating use case

Downstream projects with mathlib as a dependency currently hit OOMs when
running `leanchecker: true` on `ubuntu-latest` (7 GB). The cause is the
parallel `IO.asTask` fan-out in [src/LeanChecker.lean](https://github.com/leanprover/lean4/blob/v4.29.0/src/LeanChecker.lean):
each target module loads its own copy of the transitive import
environment, and Lean's task scheduler runs up to `hardware_concurrency()`
of them concurrently. With all-of-mathlib in the import closure, that
doesn't fit on a hosted runner.

A workaround is to cap Lean's task scheduler to 1 thread via
`LEAN_NUM_THREADS=1`, but to do that today users have to drop
`leanchecker: true` and reimplement the step manually. Example of what
projects are resorting to (shell loop with subprocess-per-module):
https://github.com/merely-true/merely-true/blob/bump-v4.29.0/.github/workflows/lean_action_ci.yml

`leanchecker-args` doesn't directly solve the OOM, but it's the minimum
useful surface so those projects can add their own target list
(`leanchecker-args: "MyPkg.Core MyPkg.Utils"`) or verbose output (`-v`)
without forking the action. Once a `--jobs` / sequential flag lands in
`leanchecker` itself, users can flip it through this input with no
further action changes required.

## Changes

- new `leanchecker-args` input (default: `""`)
- `scripts/run_leanchecker.sh` passes `$LEANCHECKER_ARGS` via `eval`,
  matching the pattern in `scripts/lake_build.sh`
- CHANGELOG + README entries

## Test plan

- [ ] manual: `leanchecker-args: "-v"` on a small test project produces
      per-module replay output
- [ ] manual: `leanchecker-args: "NonexistentMod"` fails with the usual
      "Could not find any oleans" error (args are being passed through)

🤖 Prepared with Claude Code