### PR TITLE
fix: use a more portable shebang

### DIFF
--- a/.github/functional_tests/test_helpers/verify_action_output.sh
+++ b/.github/functional_tests/test_helpers/verify_action_output.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Expects the following environment variables to be set in the calling job step:
 # - OUTPUT_NAME: the name of the output to verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- use a more portable shebang, useful for self-hosted runners
+
 ## v1.5.0 - 2026-04-21
 
 ### Added

--- a/scripts/check_reservoir_eligibility.sh
+++ b/scripts/check_reservoir_eligibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Group logging using the ::group:: workflow command
 echo "::group::Reservoir Eligibility Check Output"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # start log group

--- a/scripts/detect_mathlib.sh
+++ b/scripts/detect_mathlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Group logging using the ::group:: workflow command
 echo "::group::Detect Mathlib Output"

--- a/scripts/install_elan.sh
+++ b/scripts/install_elan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Group logging using the ::group:: workflow command

--- a/scripts/lake_build.sh
+++ b/scripts/lake_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # start log group

--- a/scripts/lake_lint.sh
+++ b/scripts/lake_lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "::group::Lake Lint Output"

--- a/scripts/lake_test.sh
+++ b/scripts/lake_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # start log group

--- a/scripts/mk_all_check.sh
+++ b/scripts/mk_all_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "::group::mk_all Output"

--- a/scripts/run_leanchecker.sh
+++ b/scripts/run_leanchecker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 echo "::group::leanchecker Output"

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Group logging using the ::group:: workflow command

--- a/scripts/set_output_parameters.sh
+++ b/scripts/set_output_parameters.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Group logging using the ::group:: workflow command
 echo "::group::Set Output Parameters"


### PR DESCRIPTION
`/usr/bin/env bash` is more portable than a plain `/bin/bash`.