### PR TITLE
feat: add opt-in axiom-audit check

### DIFF
--- a/.github/functional_tests/axiom_audit/action.yml
+++ b/.github/functional_tests/axiom_audit/action.yml
@@ -1,0 +1,58 @@
+name: 'axiom-audit test'
+description: 'Verify the axiom-audit check succeeds on a clean package and fails once a home-rolled axiom is introduced.'
+inputs:
+  toolchain:
+    description: 'Toolchain to use for the test'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    # TODO: once `lean-action` supports just setup, use it here
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: create a clean lake library
+      run: |
+        lake init foo lib
+        lake update
+      shell: bash
+
+    - name: "run `lean-action` (clean package)"
+      id: lean-action-clean
+      uses: ./
+      with:
+        use-github-cache: false
+        axiom-audit: true
+
+    - name: verify axiom-audit success on the clean package
+      env:
+        OUTPUT_NAME: "axiom-audit-status"
+        EXPECTED_VALUE: "SUCCESS"
+        ACTUAL_VALUE: ${{ steps.lean-action-clean.outputs.axiom-audit-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    - name: introduce a home-rolled axiom
+      run: |
+        printf '\naxiom fooBad : True\ntheorem fooUsesBad : True := fooBad\n' >> Foo/Basic.lean
+      shell: bash
+
+    - name: "rerun `lean-action` (axiom introduced)"
+      id: lean-action-dirty
+      uses: ./
+      continue-on-error: true # required so that the failing audit does not fail the workflow
+      with:
+        use-github-cache: false
+        axiom-audit: true
+
+    - name: verify axiom-audit failure once an axiom is introduced
+      env:
+        OUTPUT_NAME: "axiom-audit-status"
+        EXPECTED_VALUE: "FAILURE"
+        ACTUAL_VALUE: ${{ steps.lean-action-dirty.outputs.axiom-audit-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -173,7 +173,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/functional_tests/axiom_audit
         with:
-          toolchain: ${{ env.toolchain }}
+          # axiom-audit builds with the project's toolchain, so use a recent one.
+          toolchain: ${{ env.modern_toolchain }}
 
   macos-runner:
     runs-on: macos-latest

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -217,13 +217,14 @@ jobs:
           toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   axiom_audit:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./.github/functional_tests/axiom_audit
         with:
           # axiom-audit builds with the project's toolchain, so use a recent one.
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   macos-runner:
     needs: resolve-toolchain

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -176,7 +176,7 @@ jobs:
       - uses: ./.github/functional_tests/axiom_audit
         with:
           # axiom-audit builds with the project's toolchain, so use a recent one.
-          toolchain: ${{ env.modern_toolchain }}
+          toolchain: ${{ env.toolchain }}
 
   macos-runner:
     runs-on: macos-latest

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -167,6 +167,14 @@ jobs:
         with:
           toolchain: ${{ env.toolchain }}
 
+  axiom_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/functional_tests/axiom_audit
+        with:
+          toolchain: ${{ env.toolchain }}
+
   macos-runner:
     runs-on: macos-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- new `axiom-audit` input to audit the project's axioms with [axiom-audit](https://github.com/leanprover-community/axiom-audit): fail if any declaration depends on an axiom outside the allowlist (catches `sorry`, `native_decide`, and home-rolled axioms). Default: false
+- new `axiom-audit-allow` input for the allowlist (default: `propext,Classical.choice,Quot.sound`)
+- new `axiom-audit-root` input to set the audited root namespace (default: the lakefile's library name)
+- new `axiom-audit-status` output parameter
+
 ## v1.5.0 - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Default: "true"
     nanoda-allow-sorry: ""
 
+    # Audit the project's axioms with leanprover-community/axiom-audit: fail if any declaration
+    # depends on an axiom outside the allowlist (catches sorry, native_decide, home-rolled axioms).
+    # Allowed values: "true" | "false".
+    # Default: "false"
+    axiom-audit: ""
+
+    # Comma-separated allowlist of axioms for axiom-audit (no spaces).
+    # Default: "propext,Classical.choice,Quot.sound"
+    axiom-audit-allow: ""
+
+    # The root namespace axiom-audit should audit. If empty, the lakefile's library name is used.
+    # Default: ""
+    axiom-audit-root: ""
+
     # Enable GitHub caching.
     # Allowed values: "true" or "false".
     # If use-github-cache input is not provided, the action will use GitHub caching by default.
@@ -253,6 +267,8 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
 - `mk_all-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 - `nanoda-status`
+  - Values: "SUCCESS" | "FAILURE" | ""
+- `axiom-audit-status`
   - Values: "SUCCESS" | "FAILURE" | ""
 
 Note, a value of empty string indicates `lean-action` did not run the corresponding feature.
@@ -316,6 +332,32 @@ steps:
     run: |
       lake exe graph
       rm import_graph.dot
+```
+
+## Axiom Allowlist Audit with axiom-audit
+
+[axiom-audit](https://github.com/leanprover-community/axiom-audit) checks that every declaration in your library depends only on an allowlist of axioms (by default `propext`, `Classical.choice`, `Quot.sound`). Because it inspects the compiled kernel environment, it catches what a `grep` cannot: `sorry`/`admit` (`sorryAx`), `native_decide` (`Lean.ofReduceBool`), and any home-rolled `axiom`, including ones reaching in through imports.
+
+The tool is cloned and built with your project's own toolchain, then run against your compiled environment, so it needs a recent enough Lean (see the axiom-audit README). It is opt-in (default off).
+
+### Enable the axiom audit
+
+```yaml
+- uses: leanprover/lean-action@v1
+  with:
+    axiom-audit: true
+```
+
+### Customize the allowlist or root namespace
+
+By default the audit runs over the lakefile's library namespace and allows `propext,Classical.choice,Quot.sound`. To change either:
+
+```yaml
+- uses: leanprover/lean-action@v1
+  with:
+    axiom-audit: true
+    axiom-audit-allow: "propext,Classical.choice,Quot.sound,sorryAx"  # e.g. tolerate sorry
+    axiom-audit-root: "MyLib"                                          # if it differs from the library name
 ```
 
 ## External Type Checking with nanoda

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,30 @@ inputs:
       Allowed values: "true" | "false".
     required: false
     default: "true"
+  axiom-audit:
+    description: |
+      Audit the project's axioms with leanprover-community/axiom-audit: fail if any declaration
+      defined under the project's root namespace transitively depends on an axiom outside the
+      allowlist. Catches `sorry`/`admit` (`sorryAx`), `native_decide` (`Lean.ofReduceBool`), and
+      home-rolled axioms, including ones reaching in through imports. The tool is cloned and built
+      with the project's own toolchain (so it needs a recent enough Lean; see the axiom-audit
+      README), then run against the project's compiled environment.
+      Allowed values: "true" | "false".
+    required: false
+    default: "false"
+  axiom-audit-allow:
+    description: |
+      Comma-separated allowlist of axioms for `axiom-audit` (no spaces).
+      Allowed values: a comma-separated list of axiom names.
+    required: false
+    default: "propext,Classical.choice,Quot.sound"
+  axiom-audit-root:
+    description: |
+      The root namespace `axiom-audit` should audit. If empty, the package name from the
+      lakefile is used.
+      Allowed values: a Lean namespace, or "" to auto-detect.
+    required: false
+    default: ""
   use-github-cache:
     description: |
       Enable GitHub caching.
@@ -158,6 +182,11 @@ outputs:
       The status of the nanoda check step.
       Allowed values: "SUCCESS" | "FAILURE" | "".
     value: ${{ steps.nanoda.outputs.nanoda-status }}
+  axiom-audit-status:
+    description: |
+      The status of the axiom-audit check step.
+      Allowed values: "SUCCESS" | "FAILURE" | "".
+    value: ${{ steps.axiom-audit.outputs.axiom-audit-status }}
 
 runs:
   using: "composite"
@@ -300,5 +329,17 @@ runs:
       run: |
         : Check Environment with nanoda
         ${GITHUB_ACTION_PATH}/scripts/run_nanoda.sh
+      shell: bash
+      working-directory: ${{ inputs.lake-package-directory }}
+
+    - name: audit axioms with axiom-audit
+      id: axiom-audit
+      if: ${{ inputs.axiom-audit == 'true' }}
+      env:
+        AXIOM_AUDIT_ALLOW: ${{ inputs.axiom-audit-allow }}
+        AXIOM_AUDIT_ROOT: ${{ inputs.axiom-audit-root }}
+      run: |
+        : Audit axioms with axiom-audit
+        ${GITHUB_ACTION_PATH}/scripts/run_axiom_audit.sh
       shell: bash
       working-directory: ${{ inputs.lake-package-directory }}

--- a/action.yml
+++ b/action.yml
@@ -125,8 +125,8 @@ inputs:
     default: "propext,Classical.choice,Quot.sound"
   axiom-audit-root:
     description: |
-      The root namespace `axiom-audit` should audit. If empty, the package name from the
-      lakefile is used.
+      The root namespace `axiom-audit` should audit. If empty, the tool auto-detects it from the
+      first `lean_lib` in the lakefile.
       Allowed values: a Lean namespace, or "" to auto-detect.
     required: false
     default: ""

--- a/scripts/run_axiom_audit.sh
+++ b/scripts/run_axiom_audit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Group logging using the ::group:: workflow command

--- a/scripts/run_axiom_audit.sh
+++ b/scripts/run_axiom_audit.sh
@@ -1,73 +1,61 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Group logging using the ::group:: workflow command
 echo "::group::axiom-audit Output"
 echo "Auditing axioms with leanprover-community/axiom-audit"
 
-# Pin the tool to a released tag so the action is reproducible.
-AXIOM_AUDIT_REF="v0.1.0"
+# Pin the tool by tag for readability AND verify the exact commit after clone (tags are mutable).
+AXIOM_AUDIT_REF="v0.1.2"
+AXIOM_AUDIT_SHA="46024e005996495c65ef609368e11ab39c4222e3"
 
-# handle_exit function to capture exit status and cleanup
+# Work in a temp dir outside the package tree (avoids touching/colliding with the project).
+WORKDIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/axiom-audit.XXXXXX")"
+
+# handle_exit captures the failing command's status, records the step output, cleans up, and
+# re-exits with the same status.
 handle_exit() {
     exit_status=$?
-
-    # Close the log group before cleanup
     echo "::endgroup::"
-
-    # Always cleanup temporary files/directories
-    echo "Cleaning up temporary files..."
-    rm -rf _axiom_audit
-
-    if [ $exit_status -ne 0 ]; then
+    rm -rf "$WORKDIR"
+    if [ "$exit_status" -ne 0 ]; then
         echo "axiom-audit-status=FAILURE" >> "$GITHUB_OUTPUT"
         echo "::error::axiom-audit check failed"
     else
         echo "axiom-audit-status=SUCCESS" >> "$GITHUB_OUTPUT"
-        echo
     fi
+    exit "$exit_status"
 }
 trap handle_exit EXIT
 
-# Check for a conflicting directory before we start
-if [ -d "_axiom_audit" ]; then
-    echo "::error::Directory _axiom_audit already exists. Please remove it before running axiom-audit."
+# Ensure the project is built: the audit reads compiled oleans, so a `build: false` configuration
+# or a stale/partial build must not silently audit the wrong thing. `lake build` is a no-op if the
+# project is already up to date.
+echo "Building the project..."
+lake build
+
+# Clone and build the tool with the project's own toolchain (it is dependency-free, so this is a
+# quick build), and verify the pinned commit.
+echo "Fetching axiom-audit @ ${AXIOM_AUDIT_REF} (${AXIOM_AUDIT_SHA})..."
+git clone --depth 1 --branch "$AXIOM_AUDIT_REF" https://github.com/leanprover-community/axiom-audit.git "$WORKDIR/axiom-audit"
+got_sha="$(git -C "$WORKDIR/axiom-audit" rev-parse HEAD)"
+if [ "$got_sha" != "$AXIOM_AUDIT_SHA" ]; then
+    echo "::error::axiom-audit ${AXIOM_AUDIT_REF} resolved to ${got_sha}, expected ${AXIOM_AUDIT_SHA}"
     exit 1
 fi
-
-# Step 1: Determine the root namespace to audit. Prefer the explicit override; otherwise use the
-# first `lean_lib` name from the lakefile — the library's root namespace, which (unlike the package
-# name, e.g. `foo` vs the `Foo` library) is what declarations are actually defined under. Projects
-# with multiple libraries or a namespace that differs from the library name should set
-# `axiom-audit-root` explicitly.
-ROOT="$AXIOM_AUDIT_ROOT"
-if [ -z "$ROOT" ]; then
-    if [ -f "lakefile.toml" ]; then
-        ROOT=$(grep -A3 '^\[\[lean_lib\]\]' lakefile.toml | grep -m1 '^name' | sed 's/.*= *"\([^"]*\)".*/\1/' || true)
-    fi
-    if [ -z "$ROOT" ] && [ -f "lakefile.lean" ]; then
-        ROOT=$(grep -E '^\s*lean_lib\s' lakefile.lean | head -1 | awk '{print $2}' | tr -d '«»' || true)
-    fi
-fi
-if [ -z "$ROOT" ]; then
-    echo "::error::Could not determine the library root namespace from the lakefile; set the axiom-audit-root input."
-    exit 1
-fi
-echo "Auditing root namespace: $ROOT"
-echo "Allowlist: $AXIOM_AUDIT_ALLOW"
-
-# Step 2: Clone and build axiom-audit with the project's toolchain (so its olean reader matches
-# the project's Lean version). The tool is dependency-free, so this is a quick build.
-echo "Cloning and building axiom-audit @ $AXIOM_AUDIT_REF..."
-git clone --depth 1 --branch "$AXIOM_AUDIT_REF" https://github.com/leanprover-community/axiom-audit.git _axiom_audit
-cp lean-toolchain _axiom_audit/
+cp lean-toolchain "$WORKDIR/axiom-audit/"
 (
-    cd _axiom_audit
+    cd "$WORKDIR/axiom-audit"
     lake build
 )
 
-# Step 3: Run the audit against the project's own compiled environment (via `lake env`, so the
-# tool sees the project's search path). Exits non-zero on a violation, failing the step.
-lake env _axiom_audit/.lake/build/bin/axiom-audit --root "$ROOT" --allow "$AXIOM_AUDIT_ALLOW"
+# Run the audit against the project's compiled environment (via `lake env`, so the tool sees the
+# project's search path). The tool auto-detects the library root from the lakefile; pass --root
+# only when the user overrides it.
+audit_args=(--allow "$AXIOM_AUDIT_ALLOW")
+if [ -n "${AXIOM_AUDIT_ROOT:-}" ]; then
+    audit_args+=(--root "$AXIOM_AUDIT_ROOT")
+fi
+lake env "$WORKDIR/axiom-audit/.lake/build/bin/axiom-audit" "${audit_args[@]}"
 
 echo "axiom-audit completed successfully"

--- a/scripts/run_axiom_audit.sh
+++ b/scripts/run_axiom_audit.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# Group logging using the ::group:: workflow command
+echo "::group::axiom-audit Output"
+echo "Auditing axioms with leanprover-community/axiom-audit"
+
+# Pin the tool to a released tag so the action is reproducible.
+AXIOM_AUDIT_REF="v0.1.0"
+
+# handle_exit function to capture exit status and cleanup
+handle_exit() {
+    exit_status=$?
+
+    # Close the log group before cleanup
+    echo "::endgroup::"
+
+    # Always cleanup temporary files/directories
+    echo "Cleaning up temporary files..."
+    rm -rf _axiom_audit
+
+    if [ $exit_status -ne 0 ]; then
+        echo "axiom-audit-status=FAILURE" >> "$GITHUB_OUTPUT"
+        echo "::error::axiom-audit check failed"
+    else
+        echo "axiom-audit-status=SUCCESS" >> "$GITHUB_OUTPUT"
+        echo
+    fi
+}
+trap handle_exit EXIT
+
+# Check for a conflicting directory before we start
+if [ -d "_axiom_audit" ]; then
+    echo "::error::Directory _axiom_audit already exists. Please remove it before running axiom-audit."
+    exit 1
+fi
+
+# Step 1: Determine the root namespace to audit. Prefer the explicit override; otherwise use the
+# first `lean_lib` name from the lakefile — the library's root namespace, which (unlike the package
+# name, e.g. `foo` vs the `Foo` library) is what declarations are actually defined under. Projects
+# with multiple libraries or a namespace that differs from the library name should set
+# `axiom-audit-root` explicitly.
+ROOT="$AXIOM_AUDIT_ROOT"
+if [ -z "$ROOT" ]; then
+    if [ -f "lakefile.toml" ]; then
+        ROOT=$(grep -A3 '^\[\[lean_lib\]\]' lakefile.toml | grep -m1 '^name' | sed 's/.*= *"\([^"]*\)".*/\1/' || true)
+    fi
+    if [ -z "$ROOT" ] && [ -f "lakefile.lean" ]; then
+        ROOT=$(grep -E '^\s*lean_lib\s' lakefile.lean | head -1 | awk '{print $2}' | tr -d '«»' || true)
+    fi
+fi
+if [ -z "$ROOT" ]; then
+    echo "::error::Could not determine the library root namespace from the lakefile; set the axiom-audit-root input."
+    exit 1
+fi
+echo "Auditing root namespace: $ROOT"
+echo "Allowlist: $AXIOM_AUDIT_ALLOW"
+
+# Step 2: Clone and build axiom-audit with the project's toolchain (so its olean reader matches
+# the project's Lean version). The tool is dependency-free, so this is a quick build.
+echo "Cloning and building axiom-audit @ $AXIOM_AUDIT_REF..."
+git clone --depth 1 --branch "$AXIOM_AUDIT_REF" https://github.com/leanprover-community/axiom-audit.git _axiom_audit
+cp lean-toolchain _axiom_audit/
+(
+    cd _axiom_audit
+    lake build
+)
+
+# Step 3: Run the audit against the project's own compiled environment (via `lake env`, so the
+# tool sees the project's search path). Exits non-zero on a violation, failing the step.
+lake env _axiom_audit/.lake/build/bin/axiom-audit --root "$ROOT" --allow "$AXIOM_AUDIT_ALLOW"
+
+echo "axiom-audit completed successfully"


### PR DESCRIPTION
This PR adds an opt-in `axiom-audit` input that audits a project's axioms with [leanprover-community/axiom-audit](https://github.com/leanprover-community/axiom-audit): it fails CI if any declaration defined under the project's library namespace transitively depends on an axiom outside an allowlist (default `propext,Classical.choice,Quot.sound`), catching `sorry`, `native_decide` (`Lean.ofReduceBool`), and home-rolled axioms — including ones reaching in through imports. Because it inspects the compiled kernel environment, it catches what a `grep` cannot.

Modeled on the `nanoda` integration: the tool is cloned (pinned at `v0.1.0`) and built with the project's own toolchain, then run against the compiled environment via `lake env`, so **no per-project dependency** is required. New inputs `axiom-audit-allow` and `axiom-audit-root`, a new `axiom-audit-status` output, and a functional test (`.github/functional_tests/axiom_audit`) that verifies success on a clean library and failure once a home-rolled axiom is introduced.

**Default off** — like every other check here, it does nothing unless `axiom-audit: true` is set. (axiom-audit builds with the project's toolchain, so it needs a recent enough Lean; the tool's README documents the minimum.)

I verified the integration end to end locally: on a clean `lake init … lib` package the check reports `axiom-audit-status=SUCCESS` (exit 0); after appending a home-rolled `axiom`, it reports the offending declarations and `axiom-audit-status=FAILURE` (exit 1).

Context: the tool generalizes an audit from the TauCeti project; its fast shared-cache axiom collection is also being upstreamed to Lean core as [leanprover/lean4#14157](https://github.com/leanprover/lean4/pull/14157).

Implemented with assistance from Claude Code (Anthropic).