### PR TITLE
fix: include lake-package-directory in cache key hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- include `lake-package-directory` when hashing `lean-toolchain` and `lake-manifest.json` for the GitHub cache key, so projects whose Lake package lives in a subdirectory get a version-specific key instead of an empty one (the empty key previously caused stale, cross-version cache restores)
+
 ## v1.5.0 - 2026-04-21
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -207,9 +207,9 @@ runs:
       with:
         path: ${{ inputs.lake-package-directory }}/.lake
         # cache key includes the operating system, the architecture (X86, X64, ARM, ARM64), the Lake manifest, and the git commit hash
-        key: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+        key: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}-${{ github.sha }}
         # if no cache hit, fall back to the cache from previous commit
-        restore-keys: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+        restore-keys: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}
 
     - name: detect mathlib
       # only detect Mathlib if the user did not provide the mathlib-cache input
@@ -248,7 +248,7 @@ runs:
       if: ${{ inputs.use-github-cache == 'true' }}
       with:
         path: ${{ inputs.lake-package-directory }}/.lake
-        key: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+        key: lake-${{ runner.os }}-${{ runner.arch}}-${{ hashFiles(format('{0}/lean-toolchain', inputs.lake-package-directory)) }}-${{ hashFiles(format('{0}/lake-manifest.json', inputs.lake-package-directory)) }}-${{ github.sha }}
 
     - name: test ${{ github.repository }}
       id: test


### PR DESCRIPTION
The cache `path` already honors `lake-package-directory`, but the `key` and `restore-keys` hash root-relative `lean-toolchain` and `lake-manifest.json`. For a project whose Lake package lives in a subdirectory those globs match nothing, so both hashes are empty and the key carries no toolchain/manifest information. The restore-key then matches caches from any version, so after a toolchain or Mathlib bump a stale `.lake` is restored and `lake exe cache get` fails trying to check Mathlib out to the new revision.

This computes both hashes from `lake-package-directory` (default `"."`, unchanged behaviour for root-level projects) at all three call sites — the restore `key`, the `restore-keys`, and the save `key`.

Prepared by Claude Code.
