### PR TITLE
fix: pin functional test toolchain outside .github/workflows

### DIFF
--- a/.github/functional_test_toolchain
+++ b/.github/functional_test_toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.32.2

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -7,24 +7,48 @@ on:
       - "scripts/**"
       - "action.yml"
       - ".github/workflows/functional_tests.yml"
+      - ".github/functional_test_toolchain"
       - ".github/functional_tests/**"
   workflow_dispatch:
     inputs:
       toolchain:
-        description: "The Lean toolchain to use when running the tests."
+        description: "The Lean toolchain to use when running the tests. Defaults to the toolchain pinned in .github/functional_test_toolchain."
         required: false
-        default: "leanprover/lean4:v4.32.2"
+        default: ""
 
-# This environment variable is necessary in addition to the workflow_dispatch input
-# because the workflow_dispatch input is not available when the workflow is triggered by a pull request
 env:
-  toolchain: ${{ github.event.inputs.toolchain || 'leanprover/lean4:v4.32.2' }}
   # Toolchain without the bundled `leanchecker` binary,
   # used to cover the external `lean4checker` fallback path
   legacy_toolchain: leanprover/lean4:v4.26.0
 
 jobs:
+  # The default toolchain is pinned in `.github/functional_test_toolchain`
+  # rather than in this file so that the `Update Functional Test Toolchain`
+  # workflow can bump it without a token holding the `workflows` permission,
+  # which the default `GITHUB_TOKEN` cannot be granted.
+  resolve-toolchain:
+    runs-on: ubuntu-latest
+    outputs:
+      toolchain: ${{ steps.resolve.outputs.toolchain }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Resolve the functional test toolchain
+        id: resolve
+        env:
+          # The workflow_dispatch input is unset when the workflow is triggered
+          # by a pull request, in which case the pinned toolchain is used.
+          input_toolchain: ${{ github.event.inputs.toolchain }}
+        run: |
+          toolchain="${input_toolchain:-$(tr -d '[:space:]' < .github/functional_test_toolchain)}"
+          if [ -z "$toolchain" ]; then
+            echo "::error::failed to resolve the functional test toolchain"
+            exit 1
+          fi
+          echo "Using toolchain: $toolchain"
+          echo "toolchain=$toolchain" >> "$GITHUB_OUTPUT"
+
   lake-init-success:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,31 +63,34 @@ jobs:
       - uses: ./.github/functional_tests/lake_init_success
         with:
           lake-init-arguments: ${{ matrix.lake-init-arguments}}
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-init-failure:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_init_failure
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   auto-config-true:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/auto_config_true
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   auto-config-false:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/auto_config_false
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   auto-config-false-legacy-leanchecker:
     runs-on: ubuntu-latest
@@ -74,77 +101,86 @@ jobs:
           toolchain: ${{ env.legacy_toolchain }}
 
   lake-build-args:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_build_args
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-test-args:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_test_args
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   detect-mathlib:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/mathlib_dependency
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-test-success:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_test_success
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-test-failure:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_test_failure
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-lint-success:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_lint_success
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-lint-failure:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_lint_failure
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-check-test-failure:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_check_test_failure
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   subdirectory-lake-package:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/subdirectory_lake_package
         with:
-          toolchain: ${{ env.toolchain }}
-  
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
+
   subdirectory-lake-package-lean-checker:
     runs-on: ubuntu-latest
     steps:
@@ -154,35 +190,39 @@ jobs:
           toolchain: ${{ env.legacy_toolchain }}
 
   reinstall-transient-toolchain:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/reinstall-transient-toolchain
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   mk_all-check:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/mk_all-check
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   macos-runner:
+    needs: resolve-toolchain
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_init_success
         with:
           lake-init-arguments: "standalone"
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   windows-runner:
+    needs: resolve-toolchain
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_init_success
         with:
           lake-init-arguments: "standalone"
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}

--- a/.github/workflows/update_functional_test_toolchain.yml
+++ b/.github/workflows/update_functional_test_toolchain.yml
@@ -1,6 +1,11 @@
 # Nightly job which checks the latest Lean release (including release
 # candidates) and, if it is newer than the toolchain used by the functional
-# tests, opens a PR updating .github/workflows/functional_tests.yml.
+# tests, opens a PR updating .github/functional_test_toolchain.
+#
+# The toolchain is pinned in its own file rather than in
+# .github/workflows/functional_tests.yml because pushing a change to any file
+# under .github/workflows/ requires a token with the `workflows` permission,
+# which the default GITHUB_TOKEN cannot be granted.
 #
 # Note: PRs created with the default GITHUB_TOKEN do not trigger
 # `pull_request` workflows (so the functional tests will not run on the
@@ -39,7 +44,7 @@ jobs:
           latest=$(gh api repos/leanprover/lean4/releases \
             --jq '.[] | select(.draft | not) | .tag_name' \
             | tr -- '-' '~' | sort -V | tail -n 1 | tr -- '~' '-')
-          current=$(sed -n "s#.*|| 'leanprover/lean4:\(v[^']*\)'.*#\1#p" .github/workflows/functional_tests.yml)
+          current=$(sed -n 's#^leanprover/lean4:\(v.*\)$#\1#p' .github/functional_test_toolchain)
 
           if [ -z "$latest" ] || [ -z "$current" ]; then
             echo "::error::failed to determine versions (latest='$latest', current='$current')"
@@ -59,13 +64,12 @@ jobs:
           echo "latest=$latest" >> "$GITHUB_OUTPUT"
           echo "current=$current" >> "$GITHUB_OUTPUT"
 
-      - name: Update functional_tests.yml
+      - name: Update the pinned functional test toolchain
         if: steps.check.outputs.update == 'true'
         env:
-          CURRENT: ${{ steps.check.outputs.current }}
           LATEST: ${{ steps.check.outputs.latest }}
         run: |
-          sed -i "s#leanprover/lean4:${CURRENT}#leanprover/lean4:${LATEST}#g" .github/workflows/functional_tests.yml
+          echo "leanprover/lean4:${LATEST}" > .github/functional_test_toolchain
 
       - name: Create pull request
         if: steps.check.outputs.update == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,12 @@ Here are the steps to create a new test:
 
 ### Running functional tests with a specific Lean toolchain
 When triggered by a pull request,
-the `functional_tests.yml` workflow uses the Lean toolchain defined in the `toolchain` environment variable
-at the top of the `functional_tests.yml`  workflow file.
+the `functional_tests.yml` workflow uses the Lean toolchain pinned in the
+`.github/functional_test_toolchain` file.
+The toolchain lives in its own file rather than in the workflow
+so that the `update_functional_test_toolchain.yml` workflow can bump it automatically;
+pushing changes to files under `.github/workflows/` requires a token with the `workflows` permission,
+which the default `GITHUB_TOKEN` cannot be granted.
 
 When `functional_tests.yml` is triggered by a manual workflow dispatch,
 users can specify the Lean toolchain as seen in the below screenshot.


### PR DESCRIPTION
The nightly [Update Functional Test Toolchain](https://github.com/leanprover/lean-action/actions/workflows/update_functional_test_toolchain.yml) job fails whenever a newer Lean release exists ([example run](https://github.com/leanprover/lean-action/actions/runs/30730139508)). It detects the release and rewrites `.github/workflows/functional_tests.yml` correctly, then dies on the push:

```
! [remote rejected] auto-update/functional-test-toolchain
  (refusing to allow a GitHub App to create or update workflow
   `.github/workflows/functional_tests.yml` without `workflows` permission)
```

GitHub blocks any token from committing to files under `.github/workflows/` unless it carries the `workflow` scope. The default `GITHUB_TOKEN` cannot have it — `workflows: write` is not a grantable key in a workflow's `permissions:` block — so no permissions change can fix this.

This PR removes the need for such a token by moving the pinned toolchain out of the workflow file:

- `.github/functional_test_toolchain` (new) holds `leanprover/lean4:v4.32.2`, mirroring the format of Lean's own `lean-toolchain` files.
- `functional_tests.yml` gains a `resolve-toolchain` job that reads that file — or the `workflow_dispatch` input when one is given — and exposes the result as a job output. The toolchain-consuming jobs take `needs: resolve-toolchain` and reference `${{ needs.resolve-toolchain.outputs.toolchain }}`. The two legacy-`leanchecker` jobs are unchanged, since nothing auto-edits `legacy_toolchain`.
- The updater reads and writes the new file, so it no longer touches `.github/workflows/` and the default `GITHUB_TOKEN` suffices.
- The new file is added to the `paths:` filter so a toolchain bump still triggers the functional tests.

### Notes

- The `workflow_dispatch` input default is now `""` rather than a prefilled version; leaving it blank uses the pinned toolchain. The screenshot in `CONTRIBUTING.md` is slightly stale in that respect.
- This fixes the push failure only. PRs opened with `GITHUB_TOKEN` still do not trigger `pull_request` workflows, so functional tests will not run automatically on the generated PR. Setting `TOOLCHAIN_UPDATE_TOKEN` — now needing only `contents` and `pull-requests`, not `workflow` — or closing and reopening the PR remains the workaround. That caveat is still documented in the updater's header comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)