### PR TITLE
feat: add `nanoda-modules` input

### DIFF
--- a/.github/functional_tests/nanoda_modules/action.yml
+++ b/.github/functional_tests/nanoda_modules/action.yml
@@ -1,0 +1,98 @@
+name: 'Nanoda Modules Test'
+description: |
+  Run `lean-action` with `nanoda: true` and an explicit `nanoda-modules` input
+inputs:
+  toolchain:
+    description: 'Toolchain to use for the test'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    # TODO: once `lean-action` supports just setup, use it here
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain ${{ inputs.toolchain }}
+        echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      shell: bash
+
+    - name: create lake package
+      run: |
+        lake init NanodaModulesTest .lean
+        lake update
+      shell: bash
+
+    # Prepare two modules to be checked by nanoda
+    # Add to `lakefile.lean` to get build by `lake build`
+    - name: add extra modules for the nanoda-modules input
+      run: |
+        {
+          echo ""
+          echo "@[default_target]"
+          echo "lean_lib «ModuleA» where"
+          echo ""
+          echo "@[default_target]"
+          echo "lean_lib «ModuleB» where"
+        } >> lakefile.lean
+        echo "def moduleAHello := \"moduleA\"" > ModuleA.lean
+        echo "def moduleBHello := \"moduleB\"" > ModuleB.lean
+      shell: bash
+
+    # Positive test: Specify `nanoda-modules` with two modules
+    # whose names do not match the package name.
+    # Expected outcome: success
+    - name: "run `lean-action` with a valid nanoda-modules list"
+      id: lean-action
+      uses: ./
+      with:
+        nanoda: true
+        nanoda-modules: "ModuleA ModuleB"
+        nanoda-allow-sorry: false
+        use-github-cache: false
+
+    - name: verify `lean-action` outcome success
+      env:
+        OUTPUT_NAME: "lean-action.outcome"
+        EXPECTED_VALUE: "success"
+        ACTUAL_VALUE: ${{ steps.lean-action.outcome }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    - name: verify `nanoda` success
+      env:
+        OUTPUT_NAME: "nanoda-status"
+        EXPECTED_VALUE: "SUCCESS"
+        ACTUAL_VALUE: ${{ steps.lean-action.outputs.nanoda-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    # Negative test: Add a non-existent module to `nanoda-modules` input
+    # Expected outcome: failure
+    # The success would mean a regression:
+    # - `nanoda-modules` was ingored and package name used instead, or
+    # - only first/last element of `nanoda-modules` was used
+    - name: "run `lean-action` with a nanoda-modules list containing an missing module"
+      id: lean-action-missing-module
+      uses: ./
+      continue-on-error: true # required so that the action does not fail the workflow
+      with:
+        nanoda: true
+        nanoda-modules: "ModuleA MissingModule ModuleB"
+        nanoda-allow-sorry: false
+        use-github-cache: false
+
+    - name: verify `lean-action` outcome failure
+      env:
+        OUTPUT_NAME: "lean-action-missing-module.outcome"
+        EXPECTED_VALUE: "failure"
+        ACTUAL_VALUE: ${{ steps.lean-action-missing-module.outcome }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash
+
+    - name: verify `nanoda` failure
+      env:
+        OUTPUT_NAME: "nanoda-status"
+        EXPECTED_VALUE: "FAILURE"
+        ACTUAL_VALUE: ${{ steps.lean-action-missing-module.outputs.nanoda-status }}
+      run: .github/functional_tests/test_helpers/verify_action_output.sh
+      shell: bash

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -118,6 +118,15 @@ jobs:
         with:
           toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
+  nanoda-modules:
+    needs: resolve-toolchain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/functional_tests/nanoda_modules
+        with:
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
+
   detect-mathlib:
     needs: resolve-toolchain
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,13 @@ inputs:
       Allowed values: "true" | "false".
     required: false
     default: "true"
+  nanoda-modules:
+    description: |
+      The module(s) nanoda will check, given as a whitespace-separated list of
+      Lean module names. If not provided, the package name declared in `lakefile.toml`
+      or `lakefile.lean` will be used as input.
+    required: false
+    default: ""
   use-github-cache:
     description: |
       Enable GitHub caching.
@@ -299,6 +306,7 @@ runs:
       if: ${{ inputs.nanoda == 'true' }}
       env:
         NANODA_ALLOW_SORRY: ${{ inputs.nanoda-allow-sorry }}
+        NANODA_MODULES: ${{ inputs.nanoda-modules }}
       run: |
         : Check Environment with nanoda
         ${GITHUB_ACTION_PATH}/scripts/run_nanoda.sh

--- a/scripts/run_nanoda.sh
+++ b/scripts/run_nanoda.sh
@@ -65,33 +65,45 @@ git clone --depth 1 --branch debug https://github.com/ammkrn/nanoda_lib.git _nan
     cargo build --release
 )
 
-# Step 4: Detect module name from lakefile
-echo "Detecting module name..."
-MODULE_NAME=""
+# Step 4: Determine which modules to check
+# Check for the `nanoda-modules` input first
+set -f # disable globbing (wildcard expansion) in `NANODA_MODULES`
+# shellcheck disable=SC2206 # word splitting on whitespace is intended here
+MODULES=( ${NANODA_MODULES:-} )
+set +f
 
-# Try lakefile.toml first
-if [ -f "lakefile.toml" ]; then
-    # Extract name from [package] section
-    MODULE_NAME=$(grep -A5 '^\[package\]' lakefile.toml | grep '^name' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/' || true)
+if [ ${#MODULES[@]} -gt 0 ]; then
+    echo "Using modules from the nanoda-modules input: ${MODULES[*]}"
+else
+    # Fall back to the package name declared in the lakefile
+    echo "Detecting module name..."
+    MODULE_NAME=""
+
+    # Try lakefile.toml first
+    if [ -f "lakefile.toml" ]; then
+        # Extract name from [package] section
+        MODULE_NAME=$(grep -A5 '^\[package\]' lakefile.toml | grep '^name' | head -1 | sed 's/.*= *"\([^"]*\)".*/\1/' || true)
+    fi
+
+    # Fallback to lakefile.lean
+    if [ -z "$MODULE_NAME" ] && [ -f "lakefile.lean" ]; then
+        # Try to extract from 'package' declaration (allowing leading whitespace)
+        MODULE_NAME=$(grep -E "^\s*package\s+" lakefile.lean | head -1 | awk '{print $2}' || true)
+    fi
+
+    if [ -z "$MODULE_NAME" ]; then
+        echo "::error::Could not detect module name from lakefile.toml or lakefile.lean"
+        exit 1
+    fi
+
+    echo "Detected module name: $MODULE_NAME"
+    MODULES=("$MODULE_NAME")
 fi
-
-# Fallback to lakefile.lean
-if [ -z "$MODULE_NAME" ] && [ -f "lakefile.lean" ]; then
-    # Try to extract from 'package' declaration (allowing leading whitespace)
-    MODULE_NAME=$(grep -E "^\s*package\s+" lakefile.lean | head -1 | awk '{print $2}' || true)
-fi
-
-if [ -z "$MODULE_NAME" ]; then
-    echo "::error::Could not detect module name from lakefile.toml or lakefile.lean"
-    exit 1
-fi
-
-echo "Detected module name: $MODULE_NAME"
 
 # Step 5: Export the project
-echo "Exporting $MODULE_NAME..."
+echo "Exporting ${MODULES[*]}..."
 EXPORT_FILE="_nanoda_export.txt"
-lake env _lean4export/.lake/build/bin/lean4export "$MODULE_NAME" > "$EXPORT_FILE"
+lake env _lean4export/.lake/build/bin/lean4export "${MODULES[@]}" > "$EXPORT_FILE"
 
 echo "Export file size: $(wc -c < "$EXPORT_FILE") bytes"
 echo "Export file lines: $(wc -l < "$EXPORT_FILE") lines"


### PR DESCRIPTION
New optional input `nanoda-modules`: The module(s) nanoda will check, given as a whitespace-separated list of Lean module names. 

If not provided, the existing strategy is used (extract package name form`lakefile.toml` or `lakefile.lean`).

Functional test added: it fails on `Error: invalid digit found in string` as described in issue https://github.com/leanprover/lean-action/issues/169 and solved in proposed PR https://github.com/leanprover/lean-action/pull/177. I have verified both PRs together in my fork of lean-action, on a real Lean codebase.

Closes https://github.com/leanprover/lean-action/issues/179