### PR TITLE
docs: document `LEAN_NUM_THREADS` workaround for `leanchecker` memory exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ To be certain `lean-action` runs a step, specify the desire feature with a featu
     # Check environment with leanchecker.
     # Uses the bundled `leanchecker` binary on Lean `nightly-2026-01-09` / `v4.28.0-rc1`
     # and newer, and falls back to the external `lean4checker` repository on older versions.
+    # Note: Mathlib-dependent projects should set `LEAN_NUM_THREADS`,
+    # see "Run leanchecker on a project with a Mathlib dependency".
     # Allowed values: "true" | "false".
     # Default: "false"
     leanchecker: ""
@@ -322,6 +324,26 @@ steps:
       lake exe graph
       rm import_graph.dot
 ```
+
+### Run leanchecker on a project with a Mathlib dependency
+
+`leanchecker` checks modules in parallel, and each parallel check loads the
+module's full import environment.
+For Mathlib-dependent projects this can exhaust the memory of a GitHub-hosted
+runner, causing the job to hang and then fail with "The hosted runner lost
+communication with the server", with no logs.
+
+Cap the parallelism by setting `LEAN_NUM_THREADS` on the `lean-action` step:
+
+```yaml
+- uses: leanprover/lean-action@v1
+  env:
+    LEAN_NUM_THREADS: "1"
+  with:
+    leanchecker: "true"
+```
+
+Higher values trade memory for speed.
 
 ## External Type Checking with nanoda
 

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,8 @@ inputs:
       Check environment with leanchecker.
       Uses the bundled `leanchecker` binary on Lean `nightly-2026-01-09` / `v4.28.0-rc1` and newer.
       Falls back to building the external `lean4checker` repository on older Lean versions.
+      Note: Mathlib-dependent projects should set `LEAN_NUM_THREADS`, see the README
+      section "Run leanchecker on a project with a Mathlib dependency".
       Allowed values: "true" | "false".
     required: false
     default: "false"


### PR DESCRIPTION
On GitHub-hosted runners, `leanchecker: true` on a project with a Mathlib dependency exhausts runner memory. `leanchecker` replays every module in parallel (one task per module, up to `hardware_concurrency()` concurrently) and each replay loads its own copy of the module's full import environment. Several copies of the Mathlib environment do not fit in the 16 GB of a standard public runner.

The failure mode is particularly confusing: the job hangs for a long time and then fails with "The hosted runner lost communication with the server", with no logs, because the memory exhaustion starves the runner agent itself. Nothing in that error points at leanchecker.

## Evidence

Reproduced on a 6-module project where every module imports all of Mathlib (Lean v4.32.2, `lean-action@main`, public `ubuntu-latest`):
https://github.com/austinletson/use-lean-standard-action-with-mathlib/actions/runs/30538770587

- `leanchecker: true` with default settings: runner death after 47 minutes, no logs
- same project with `env: LEAN_NUM_THREADS: "1"` on the `lean-action` step: passes in ~2.5 minutes, both as a single invocation and as a build invocation followed by a leanchecker invocation

`LEAN_NUM_THREADS` works because `leanchecker`'s per-module tasks run at default priority on the Lean task scheduler pool, whose size is `LEAN_NUM_THREADS` (falling back to `hardware_concurrency()`), and a step-level `env:` propagates into the composite action's steps.

## Changes

- README: new "Run leanchecker on a project with a Mathlib dependency" section under Additional Examples, documenting the failure mode and the workaround, plus a pointer in the `leanchecker` input comment
- `action.yml`: matching note in the `leanchecker` input description

Docs only, no behavior change. This workaround applies to all existing releases. Follow-ups planned separately: a memory-aware `LEAN_NUM_THREADS` default in `run_leanchecker.sh` when a Mathlib dependency is detected, and an upstream request for a `--jobs`-style flag in the bundled `leanchecker` (the external lean4checker already has `--num-workers` since leanprover/lean4checker#75), which #162 would let users pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)