### PR TITLE
fix: pass resolved toolchain to `lake-lint-args` functional test

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -164,12 +164,13 @@ jobs:
           toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-lint-args:
+    needs: resolve-toolchain
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/functional_tests/lake_lint_args
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: ${{ needs.resolve-toolchain.outputs.toolchain }}
 
   lake-check-test-failure:
     needs: resolve-toolchain


### PR DESCRIPTION
The `lake-lint-args` job added in #149 is missing `needs: resolve-toolchain` and passes `toolchain: ${{ env.toolchain }}`, which is undefined. The empty value reaches `elan-init --default-toolchain`, which fails with "requires a value but none was supplied", so the job fails on every PR (first seen on #181, which is docs-only).

This wires the job to `needs.resolve-toolchain.outputs.toolchain` like the other functional test jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)