### PR TITLE
chore: add missing CHANGELOG entries for #153 and #181

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new `axiom-audit-status` output parameter
 - new `lint-args` input to specify arguments to pass to `lake lint`
 
+### Changed
+
+- document the `LEAN_NUM_THREADS` workaround for `leanchecker` memory exhaustion on projects with a Mathlib dependency
+
 ### Fixed
 
+- pass the `test-args` input through to `lake test`; the input was previously ignored
 - include `lake-package-directory` when hashing `lean-toolchain` and `lake-manifest.json` for the GitHub cache key, so projects whose Lake package lives in a subdirectory get a version-specific key instead of an empty one (the empty key previously caused stale, cross-version cache restores)
 - use a more portable shebang, useful for self-hosted runners
 


### PR DESCRIPTION
Two user-facing changes landed since `v1.5.0` without a `CHANGELOG.md` entry:

- #153 added `TEST_ARGS` to the `lake test` step env in `action.yml`. The `test-args` input, added in v1.4.0, was never passed through and so did nothing until that fix.
- #181 documented the `LEAN_NUM_THREADS` workaround for `leanchecker` memory exhaustion on Mathlib-dependent projects.

The remaining commits since `v1.5.0` are functional-test fixes, the test toolchain bump, and dependency bumps confined to `.github/workflows`, none of which affect consumers of the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)